### PR TITLE
Migrate all jobs to OIDC

### DIFF
--- a/.github/workflows/ldap-add-roles-to-users.yml
+++ b/.github/workflows/ldap-add-roles-to-users.yml
@@ -24,9 +24,9 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-                aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-                aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-                aws-region: "eu-west-2"
+              role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+              role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+              aws-region: "eu-west-2"
           - name: Set cluster ARN
             id: set-cluster-arn
             run: |

--- a/.github/workflows/ldap-data-refresh.yml
+++ b/.github/workflows/ldap-data-refresh.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Create a temporary EFS resource with AWS Backup recovery point
         id: create-efs-from-backup
         run: |
-          RESTORE_JOB_ID=$(aws backup start-restore-job --recovery-point-arn ${{ env.RECOVERY_POINT_ARN }} --iam-role-arn arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/ldap-data-refresh-role-${{ github.event.inputs.source_env }} --metadata file-system-id=${{ env.EFS_FILE_SYSTEM_ID }},newFileSystem=true,CreationToken=gha-ldap-data-refresh-${{github.run_id }},Encrypted=true,KmsKeyId=${{ secrets.KMS_GENERAL_HMPPS_KEY_ID }},PerformanceMode=generalPurpose --resource-type EFS --no-copy-source-tags-to-restored-resource --output text --query 'RestoreJobId')
+          RESTORE_JOB_ID=$(aws backup start-restore-job --recovery-point-arn ${{ env.RECOVERY_POINT_ARN }} --iam-role-arn arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/ldap-data-refresh-role-${{ github.event.inputs.source_env }} --metadata file-system-id=${{ env.EFS_FILE_SYSTEM_ID }},newFileSystem=true,CreationToken=gha-ldap-data-refresh-${{github.run_id }},Encrypted=false,PerformanceMode=generalPurpose --resource-type EFS --no-copy-source-tags-to-restored-resource --output text --query 'RestoreJobId')
           if [[ $? -eq 0 ]]; then
             echo "RESTORE_JOB_ID=$RESTORE_JOB_ID" >> $GITHUB_OUTPUT
           else

--- a/.github/workflows/ldap-data-refresh.yml
+++ b/.github/workflows/ldap-data-refresh.yml
@@ -94,7 +94,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: githubactionsrolesession
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
           aws-region: "eu-west-2"
 
       - name: Scale ECS Service to 0
@@ -126,7 +126,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: githubactionsrolesession
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
           aws-region: "eu-west-2"
 
       - name: Use latest recovery point arn
@@ -152,7 +152,7 @@ jobs:
       - name: Create a temporary EFS resource with AWS Backup recovery point
         id: create-efs-from-backup
         run: |
-          RESTORE_JOB_ID=$(aws backup start-restore-job --recovery-point-arn ${{ env.RECOVERY_POINT_ARN }} --iam-role-arn arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/ldap-data-refresh-role-${{ github.event.inputs.source_env }} --metadata file-system-id=${{ env.EFS_FILE_SYSTEM_ID }},newFileSystem=true,CreationToken=gha-ldap-data-refresh-${{github.run_id }},Encrypted=false,PerformanceMode=generalPurpose --resource-type EFS --no-copy-source-tags-to-restored-resource --output text --query 'RestoreJobId')
+          RESTORE_JOB_ID=$(aws backup start-restore-job --recovery-point-arn ${{ env.RECOVERY_POINT_ARN }} --iam-role-arn arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/ldap-data-refresh-role-${{ github.event.inputs.source_env }} --metadata file-system-id=${{ env.EFS_FILE_SYSTEM_ID }},newFileSystem=true,CreationToken=gha-ldap-data-refresh-${{github.run_id }},Encrypted=true,KmsKeyId=${{ secrets.KMS_GENERAL_HMPPS_KEY_ID }},PerformanceMode=generalPurpose --resource-type EFS --no-copy-source-tags-to-restored-resource --output text --query 'RestoreJobId')
           if [[ $? -eq 0 ]]; then
             echo "RESTORE_JOB_ID=$RESTORE_JOB_ID" >> $GITHUB_OUTPUT
           else
@@ -290,7 +290,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: githubactionsrolesession
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
           aws-region: "eu-west-2"
 
       - name: Get first directory listed in s3 bucket
@@ -373,7 +373,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: githubactionsrolesession
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
           aws-region: "eu-west-2"
 
       - name: Scale ECS Service back to 1
@@ -399,7 +399,7 @@ jobs:
         uses: aws-actions/configure-aws-credentials@v4
         with:
           role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
-          role-session-name: githubactionsrolesession
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
           aws-region: "eu-west-2"
 
       - name: Remove EFS access point and mount targets
@@ -495,4 +495,4 @@ jobs:
           else
             echo "At least one step failed, marking the job as failed"
             exit 1
-          fi          
+          fi

--- a/.github/workflows/ldap-operational-automation-template.yml
+++ b/.github/workflows/ldap-operational-automation-template.yml
@@ -25,9 +25,9 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-                aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-                aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-                aws-region: "eu-west-2"
+              role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+              role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+              aws-region: "eu-west-2"
           - name: Set cluster ARN
             id: set-cluster-arn
             run: |

--- a/.github/workflows/ldap-rbac-uplift.yml
+++ b/.github/workflows/ldap-rbac-uplift.yml
@@ -22,9 +22,9 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-                aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-                aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-                aws-region: "eu-west-2"
+              role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+              role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+              aws-region: "eu-west-2"
           - name: Set cluster ARN
             id: set-cluster-arn
             run: |

--- a/.github/workflows/ldap-update-user-home-area.yml
+++ b/.github/workflows/ldap-update-user-home-area.yml
@@ -26,9 +26,9 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-                aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-                aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-                aws-region: "eu-west-2"
+              role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+              role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+              aws-region: "eu-west-2"
           - name: Set cluster ARN
             id: set-cluster-arn
             run: |

--- a/.github/workflows/ldap-update-user-roles.yml
+++ b/.github/workflows/ldap-update-user-roles.yml
@@ -44,9 +44,9 @@ jobs:
           - name: Configure AWS Credentials
             uses: aws-actions/configure-aws-credentials@v4
             with:
-                aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-                aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-                aws-region: "eu-west-2"
+              role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+              role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+              aws-region: "eu-west-2"
           - name: Set cluster ARN
             id: set-cluster-arn
             run: |

--- a/.github/workflows/oracle-db-autotasks.yml
+++ b/.github/workflows/oracle-db-autotasks.yml
@@ -87,9 +87,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Configure Oracle Autotasks
         run: $command -i $inventory -e target_hosts=${{needs.build_target_name.outputs.TargetHost}}

--- a/.github/workflows/oracle-db-backup.yml
+++ b/.github/workflows/oracle-db-backup.yml
@@ -176,9 +176,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Start Ansible Backup
         run: $backup_command -i $inventory -e rman_target=$RmanTarget -e daily_weekly=$Period -e enable_trace=$EnableTrace $VerboseOutput

--- a/.github/workflows/oracle-db-block-sessions.yml
+++ b/.github/workflows/oracle-db-block-sessions.yml
@@ -101,9 +101,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Block Sessions
         run: $command -i $inventory -e target_host=$TargetHost -e action=${{ github.event.inputs.Action }}

--- a/.github/workflows/oracle-db-build-ha.yml
+++ b/.github/workflows/oracle-db-build-ha.yml
@@ -138,9 +138,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Check Fast Start Fail Over Ansible Variable
         id: getfsfomode

--- a/.github/workflows/oracle-db-delius-configuration-artefacts.yml
+++ b/.github/workflows/oracle-db-delius-configuration-artefacts.yml
@@ -125,9 +125,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Run Delius Artefacts Playbook
         run: |

--- a/.github/workflows/oracle-db-delius-operational-artefacts.yml
+++ b/.github/workflows/oracle-db-delius-operational-artefacts.yml
@@ -129,9 +129,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Run Delius Artefacts Playbook
         run: |

--- a/.github/workflows/oracle-db-patching.yml
+++ b/.github/workflows/oracle-db-patching.yml
@@ -113,9 +113,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Start Oracle Patching
         run: |

--- a/.github/workflows/oracle-db-restore-points.yml
+++ b/.github/workflows/oracle-db-restore-points.yml
@@ -180,9 +180,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Start Ansible Validate Backup
         run: 

--- a/.github/workflows/oracle-db-set-parameters.yml
+++ b/.github/workflows/oracle-db-set-parameters.yml
@@ -86,9 +86,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Start Set Parameters
         run: $command -i $inventory -e target_host=${{needs.build_target_name.outputs.TargetHost}}

--- a/.github/workflows/oracle-db-validate-backups.yml
+++ b/.github/workflows/oracle-db-validate-backups.yml
@@ -187,9 +187,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Start Ansible Validate Backup
         run: |

--- a/.github/workflows/test-automation-task.yml
+++ b/.github/workflows/test-automation-task.yml
@@ -50,9 +50,9 @@ jobs:
         id: login-aws
         uses: aws-actions/configure-aws-credentials@v4
         with:
-          aws-access-key-id: ${{ secrets.CICD_ACCESS_KEY }}
-          aws-secret-access-key: ${{ secrets.CICD_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.AWS_REGION }}
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
 
       - name: Test ansible
         working-directory: ansible


### PR DESCRIPTION
This may well partly break some jobs, but the alternative is all jobs stop working due to deprecation of the `cicd-member-user` user.