### PR TITLE
DST-16650 Use preapproved environments for Delius RBAC uplift

### DIFF
--- a/.github/workflows/ldap-rbac-uplift.yml
+++ b/.github/workflows/ldap-rbac-uplift.yml
@@ -11,11 +11,10 @@ on:
       rbac_tag:
         required: true
         type: string
-  workflow_call:
 
 jobs:
     deploy:
-        name: Create ECS Task in delius-core ${{ github.event.inputs.environment }}
+        name: Create ECS Task in delius-core ${{ github.event.inputs.environment }}-preapproved
         runs-on: ubuntu-latest
         environment: delius-core-${{ github.event.inputs.environment }}
         permissions:


### PR DESCRIPTION
This will be initiated from the GitHub Actions pipeline in the delius-releases, which already has approval gates for each environment.