### PR TITLE
DBA-844

### DIFF
--- a/playbooks/delius-artefacts-playbook.yml
+++ b/playbooks/delius-artefacts-playbook.yml
@@ -87,5 +87,8 @@
   gather_facts: no
   become: yes
   become_user: oracle
-  roles:
-    - { role: "{{ playbook_dir }}/alfresco_wallet/alfresco_wallet", when: ( deploy_alfresco_wallet | default('no') == "yes" ) }
+  tasks:
+    - name: Deploy Alfresco Wallet
+      include_role:
+        name: "{{ playbook_dir }}/alfresco_wallet/alfresco_wallet"
+      when: deploy_alfresco_wallet | default('no') == "yes"


### PR DESCRIPTION
Commit Description:
Refactor Alfresco Wallet Role Inclusion to Use include_role to avoid error when run from MIS Config Artefact workflow

Summary of Change:
Replaced the roles section for the alfresco_wallet role in playbooks/delius-artefacts-playbook.yml with a task that uses the include_role module. This ensures the role is conditionally included at runtime based on the deploy_alfresco_wallet variable.

Reason for Change:
Ansible pre-checks for the existence of roles in the roles section, even when they are conditionally included. This caused errors in workflows (e.g., oracle-db-mis-configuration-artefacts.yml) where the alfresco_wallet role was not needed and its directory did not exist. Using include_role delays role inclusion until the when condition is evaluated, avoiding the unnecessary pre-check and error.

Tested with workflow run ["Oracle: delius-mis-dev_mis_configuration_artefacts #21"](https://github.com/ministryofjustice/hmpps-delius-operational-automation/actions/runs/12873608689/job/35891491732)