### PR TITLE
Allow archivelog only backup to be run

### DIFF
--- a/playbooks/oracle_backup/backup.yml
+++ b/playbooks/oracle_backup/backup.yml
@@ -55,6 +55,17 @@
           set_fact:
             rman_options: "-t HOT -i 0 -b Y"
           when: daily_weekly == 'weekly'
+  
+        - fail:
+             msg: "The range of sequence numbers to be backed up must be specified in archivelog mode"
+          when:
+             - daily_weekly == 'archivelog'
+             - min_seq is not defined
+
+        - name: Set rman_options when "archivelog"
+          set_fact:
+            rman_options: "-t HOT -i 0 -b Y -a {{ min_seq }},{{ max_seq | default(min_seq) }}"
+          when: daily_weekly == 'archivelog'
 
         - name: Setup catalog connect identifier in tnsnames if catalog defined
           include_tasks: setup-catalog-tnsnames.yml

--- a/playbooks/oracle_backup/backup.yml
+++ b/playbooks/oracle_backup/backup.yml
@@ -55,12 +55,12 @@
           set_fact:
             rman_options: "-t HOT -i 0 -b Y"
           when: daily_weekly == 'weekly'
-  
+
         - fail:
-             msg: "The range of sequence numbers to be backed up must be specified in archivelog mode"
+            msg: "The range of sequence numbers to be backed up must be specified in archivelog mode"
           when:
-             - daily_weekly == 'archivelog'
-             - min_seq is not defined
+            - daily_weekly == 'archivelog'
+            - min_seq is not defined
 
         - name: Set rman_options when "archivelog"
           set_fact:


### PR DESCRIPTION
Not currently required from GHA - only from Ansible.