### PR TITLE
database validate schedule update

### DIFF
--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -1,8 +1,8 @@
 name: "Oracle: Schedule Validate Backups"
 on:
   schedule:
-    - cron: '20 14 * * WED'
-    - cron: '20 15 * * WED'
+    - cron: '20 14 * * THU'
+    - cron: '20 15 * * THU'
     - cron: '00 18 * * TUE'
 jobs:
   prepare-run-matrix:

--- a/.github/workflows/oracle-db-validate-backups-schedule.json
+++ b/.github/workflows/oracle-db-validate-backups-schedule.json
@@ -1,13 +1,8 @@
 [
     {
         "TargetEnvironment":"delius-core-dev",
-        "TargetHost":"delius_primarydb",
-        "CronSchedule":"20 14 * * WED"
-    },
-    {
-        "TargetEnvironment":"delius-core-dev",
         "TargetHost":"delius_standbydb1",
-        "CronSchedule":"20 15 * * WED"
+        "CronSchedule":"20 15 * * THU"
     },
     {
         "TargetEnvironment":"delius-core-test",
@@ -17,16 +12,16 @@
     {
         "TargetEnvironment":"delius-mis-dev",
         "TargetHost":"mis_primarydb",
-        "CronSchedule":"20 15 * * WED"
+        "CronSchedule":"20 15 * * THU"
     },
     {
         "TargetEnvironment":"delius-mis-dev",
         "TargetHost":"boe_primarydb",
-        "CronSchedule":"20 15 * * WED"
+        "CronSchedule":"20 15 * * THU"
     },
     {
         "TargetEnvironment":"delius-mis-dev",
         "TargetHost":"dsd_primarydb",
-        "CronSchedule":"20 15 * * WED"
+        "CronSchedule":"20 15 * * THU"
     }
 ]


### PR DESCRIPTION
The schedule for validate database backup and restore job changed from Wed to Thu to allow a full level 0 backup to complete on Wed before the validate database runs.