### PR TITLE
DBA-949 OEM Blackout fix when emctl variable is not defined

### DIFF
--- a/playbooks/oem_blackout/oem-blackout/tasks/main.yml
+++ b/playbooks/oem_blackout/oem-blackout/tasks/main.yml
@@ -1,3 +1,8 @@
+- name: Set default value for emctl_agent if not defined
+  set_fact:
+    emctl_agent: "/u01/app/oracle/product/oem-agent/agent_inst/bin/emctl"
+  when: emctl_agent is not defined
+
 - name: Check if Cloud Control Agent Installed
   stat:
     path: "{{ emctl_agent }}"


### PR DESCRIPTION
Set default value if the env file for the host hasn't had the var defined, which is the case for nomis/oasys hosts.