### PR TITLE
Update oracle-db-release-update.yml

### DIFF
--- a/.github/workflows/oracle-db-release-update.yml
+++ b/.github/workflows/oracle-db-release-update.yml
@@ -120,7 +120,19 @@ jobs:
           host_prefix="environment_name_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/pre-prod/preproduction_pre_prod/;s/-prod/_production_prod/;s/-/_/g')_"
           hosts=$(echo ${{ github.event.inputs.TargetHost }} | awk -v p="$host_prefix" 'BEGIN{FS=OFS=","};{for(i=1;i<=NF;i++)$i=p $i};1')
           echo "hosts=${hosts}" >> $GITHUB_OUTPUT
-          echo "application=$(echo ${{ github.event.inputs.TargetHost }} | sed 's/_.*//')" >> $GITHUB_OUTPUT
+          # Mapping from hostname prefix to application name
+          declare -A host_to_app=(
+            [boe]=misboe
+            [dsd]=misdsd
+            [mis]=mis
+            [delius]=delius
+          )
+          # Extract first prefix from the first hostname
+          first_host=$(echo "${{ github.event.inputs.TargetHost }}" | cut -d',' -f1)
+          host_prefix_key=$(echo "$first_host" | cut -d'_' -f1)
+          # Lookup application
+          application="${host_to_app[$host_prefix_key]}"
+          echo "application=$(echo ${application} | sed 's/_.*//')" >> $GITHUB_OUTPUT
 
       - name: Checkout Inventory From modernisation-platform-configuration-management
         uses: actions/checkout@v4


### PR DESCRIPTION
The switch-clone failed on the MIS BOE and DSD hosts. The error is: "The conditional check 'high_availability_count[application] | int >= 1' failed. The error was: error while evaluating conditional (high_availability_count[application] | int >= 1): 'dict object' has no attribute 'boe'. 'dict object' has no attribute 'boe'"

The group_vars config has the following:
high_availability_count:
  delius: 0
  mis: 0
  misboe: 0
  misdsd: 0

Fixed logic in the workflow that sets the "application" value.