### PR TITLE
Update delius_audit_policies.sql

### DIFF
--- a/playbooks/audit_management/files/delius_audit_policies.sql
+++ b/playbooks/audit_management/files/delius_audit_policies.sql
@@ -13,7 +13,8 @@ SET VERIFY OFF
 
 prompt --Monitor common security relevant activities
 
-AUDIT POLICY ORA_SECURECONFIG;
+-- Removed due to excessive noise from users granted EXEMPT ACCESS POLICY through the DELIUS_READ_ONLY_ROLE role
+-- AUDIT POLICY ORA_SECURECONFIG;
 
 AUDIT POLICY ORA_ACCOUNT_MGMT;
 


### PR DESCRIPTION
Removed ORA_SECURECONFIG policy due to excessive noise from users granted EXEMPT ACCESS POLICY through the DELIUS_READ_ONLY_ROLE role, see https://dsdmoj.atlassian.net/browse/DBA-1034?focusedCommentId=644149 for details