### PR TITLE
Resolve Audit Replication DMS Task Names in Shared Accounts

### DIFF
--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
@@ -3,6 +3,9 @@
 - name: Determine the Environment Type
   include_tasks: is_audit_client.yml
 
+- debug:
+    msg: "Finding replication tasks for the {{ target_environment_name }} Delius environment."
+
 - name: Get ARN for Audited Interaction Replication Task
   shell: |
     aws dms describe-replication-tasks --region {{ region }}  | \  

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
@@ -10,7 +10,7 @@
 - name: Get ARN for Audited Interaction Replication Task
   shell: |
     aws dms describe-replication-tasks --region {{ region }}  | \  
-       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("-audited-interaction-(inbound|outbound)-")) | .ReplicationTaskArn'
+       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("{{ target_environment_name.split('-') | last }}-audited-interaction-(inbound|outbound)-")) | .ReplicationTaskArn'
   register: get_audited_interaction_task_arn
   delegate_to: localhost
   changed_when: false
@@ -24,7 +24,7 @@
 - name: Get ARN for Business Interaction Replication Task
   shell: |
     aws dms describe-replication-tasks --region {{ region }}  | \
-        jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("-business-interaction-(inbound|outbound)-")) | .ReplicationTaskArn'
+        jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("{{ target_environment_name.split('-') | last }}-business-interaction-(inbound|outbound)-")) | .ReplicationTaskArn'
   register: get_business_interaction_task_arn
   delegate_to: localhost
   changed_when: false
@@ -35,7 +35,7 @@
 - name: Get ARN for Audited Interaction Checksum Replication Task
   shell: |
     aws dms describe-replication-tasks --region {{ region }}  | \
-       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("-audited-interaction-checksum-(inbound|outbound)-")) | .ReplicationTaskArn'
+       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("{{ target_environment_name.split('-') | last }}-audited-interaction-checksum-(inbound|outbound)-")) | .ReplicationTaskArn'
   register: get_audited_interaction_checksum_task_arn
   changed_when: false
 
@@ -45,7 +45,7 @@
 - name: Get ARN for User Replication Task
   shell: |
     aws dms describe-replication-tasks  --region {{ region }}  | \
-       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("-user-(inbound|outbound)-")) | .ReplicationTaskArn'
+       jq -r '.ReplicationTasks[] | select(.ReplicationTaskIdentifier | test("{{ target_environment_name.split('-') | last }}-user-(inbound|outbound)-")) | .ReplicationTaskArn'
   register: get_user__task_arn
   changed_when: false
 

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
@@ -3,7 +3,8 @@
 - name: Determine the Environment Type
   include_tasks: is_audit_client.yml
 
-- debug:
+- name: Show Environment Name
+  debug:
     msg: "Finding replication tasks for the {{ target_environment_name }} Delius environment."
 
 - name: Get ARN for Audited Interaction Replication Task


### PR DESCRIPTION
This pull request updates the logic for finding replication tasks in the `get_task_details.yml` playbook to make the task selection specific to the target environment. It also adds a debug message to make it clearer which environment is being processed.

**Improvements to task selection logic:**

* Updated the `jq` filters in all replication task shell commands to include the environment name suffix (derived from `target_environment_name`) when matching replication task identifiers, ensuring that only tasks relevant to the current environment are selected. [[1]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2R6-R13) [[2]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L23-R27) [[3]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L34-R38) [[4]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L44-R48)

**Debugging and visibility enhancements:**

* Added a debug statement to display the current `target_environment_name`, improving visibility during playbook execution.