### PR TITLE
Handle the case where there are multiple DMS tasks of the same type in the Prod environment

### DIFF
--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/get_task_details.yml
@@ -16,10 +16,10 @@
   changed_when: false
 
 - set_fact:
-    audited_interaction_task_arn: "{{ get_audited_interaction_task_arn.stdout }}"
+    audited_interaction_task_arn: "{{ get_audited_interaction_task_arn.stdout_lines }}"
 
 - debug:
-    msg: "Audited Interaction Task ARN: {{ audited_interaction_task_arn }}"
+    msg: "Audited Interaction Task ARNs: {{ audited_interaction_task_arn }}"
 
 - name: Get ARN for Business Interaction Replication Task
   shell: |
@@ -30,7 +30,7 @@
   changed_when: false
 
 - set_fact:
-    business_interaction_task_arn: "{{ get_business_interaction_task_arn.stdout }}"
+    business_interaction_task_arn: "{{ get_business_interaction_task_arn.stdout_lines }}"
 
 - name: Get ARN for Audited Interaction Checksum Replication Task
   shell: |
@@ -40,7 +40,7 @@
   changed_when: false
 
 - set_fact:
-    audited_interaction_checksum_task_arn: "{{ get_audited_interaction_checksum_task_arn.stdout }}"
+    audited_interaction_checksum_task_arn: "{{ get_audited_interaction_checksum_task_arn.stdout_lines }}"
 
 - name: Get ARN for User Replication Task
   shell: |
@@ -50,4 +50,4 @@
   changed_when: false
 
 - set_fact:
-    user__task_arn: "{{ get_user__task_arn.stdout }}"
+    user__task_arn: "{{ get_user__task_arn.stdout_lines }}"

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/main.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/main.yml
@@ -17,19 +17,27 @@
 - name: Get Replication Task Details
   include_tasks: get_task_details.yml
 
-# If we do not find an Audited Interaction replication tasks then this environment is not configured as a client or repository
-# and no further action is needed
+# The audited_interaction_task_arn value is a list (stdout_lines), so we trim each element and
+# remove blanks before checking length. If no non-empty ARNs remain, this environment is not
+# configured as an Audited Interaction client or repository and no further action is needed.
+# This is required because in the production account there may be more than one replication task
+# of the same type (e.g. audit replication from both stage and from pre-prod)
 - name: Skip Message
   debug:
     msg: "This environment is not configured as an Audited Interaction data client or repository.  No action taken."
-  when: audited_interaction_task_arn == ''
+  when: (audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) == 0
 
 - name: Perform Requested Actions on Replication Tasks
-  when: audited_interaction_task_arn != ''
+  when: (audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
   block:
+    # We only need to wait for audit replication to finish on a client.
+    # A repository will continue to receive CDC records in the S3 bucket
+    # so can process these when it resumes.
     - name: Wait for Audit Replication to Finish
       include_tasks: wait_for_zero_throughput.yml
-      when: replication_action == 'stop'
+      when: 
+        - replication_action == 'stop'
+        - audited_interaction_client
 
     - name: Stop Replication Tasks
       include_tasks: stop_tasks.yml

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/restart_business_interaction_task.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/restart_business_interaction_task.yml
@@ -4,8 +4,12 @@
 # as we simply load all the reference data again).
 - name: Restart the Business Interaction DMS Replication Tasks with Full Load
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ business_interaction_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ business_task_arn }}" \
         --region {{ region }}  --start-replication-task-type reload-target
+  loop: "{{ business_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: business_task_arn
+  when: (business_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
 
 # Ensure the Business Interaction Task is Running before we restart the Audit
 # Replication Task since this is required to refresh the Stage Business Interaction
@@ -13,10 +17,14 @@
 - name: Wait for Business Interaction Replication Tasks to Start
   shell: |
     aws dms describe-replication-tasks \
-       --filters Name=replication-task-arn,Values="{{ business_interaction_task_arn }}" \
+       --filters Name=replication-task-arn,Values="{{ business_task_arn }}" \
         --region {{ region }}  --query "ReplicationTasks[0].Status" --output text
   register: task_status
   until: task_status.stdout == "running"
   retries: 60
   delay: 10
+  loop: "{{ business_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: business_task_arn
+  when: (business_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
   changed_when: FALSE

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/restart_tasks.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/restart_tasks.yml
@@ -22,9 +22,10 @@
 # We do not need to wait for the Audited Interaction Checksum Replication to start as the main
 # Audited Interaction data replication is not dependent on it.  We only supply a start SCN
 # on the client side of the replication
+# A client can have only 1 Audited Interaction Checksum replication tasks
 - name: Restart the Client Side Audited Interaction Checksum DMS CDC Replication Tasks from Requested Time
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_checksum_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_checksum_task_arn[0] }}" \
        --cdc-start-position "{{ audit_cdc_scn }}"  --region {{ region }}  \
        --start-replication-task-type start-replication
   when: audited_interaction_client
@@ -32,14 +33,18 @@
 # The repository does not need an SCN for a restart since it is reading from S3
 - name: Restart the Repository Side Audited Interaction Checksum DMS CDC Replication Tasks from S3
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_checksum_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ checksum_task_arn }}" \
        --region {{ region }}  \
        --start-replication-task-type start-replication
+  loop: "{{ audited_interaction_checksum_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: checksum_task_arn
   when: not audited_interaction_client
 
+# A client can have only 1 Audited Interaction Replication Tasks
 - name: Restart the Client Side Audited Interaction DMS CDC Replication Tasks from Requested Time
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_task_arn[0] }}" \
        --cdc-start-position "{{ audit_cdc_scn }}"  --region {{ region }}  \
        --start-replication-task-type start-replication
   when: audited_interaction_client
@@ -47,10 +52,15 @@
 # The repository does not need an SCN for a restart since it is reading from S3
 - name: Restart the Repository Side Audited Interaction DMS CDC Replication Tasks from S3
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ audited_task_arn }}" \
        --region {{ region }}  \
        --start-replication-task-type start-replication
-  when: not audited_interaction_client
+  loop: "{{ audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: audited_task_arn
+  when:
+    - not audited_interaction_client
+    - (audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
 
 # We cannot supply a lower bound for User and Probation Area replication since we have to use
 # an S3 bucket for staging between Mod Platform environments, and Start Positions may not
@@ -60,6 +70,10 @@
 # users into the repository whilst a client refresh is in progress.
 - name: Restart the User and Probation Area DMS CDC Replication Tasks
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ user__task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ user_task_arn }}" \
        --region {{ region }}  \
        --start-replication-task-type start-replication
+  loop: "{{ user__task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: user_task_arn
+  when: (user__task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/resume_tasks.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/resume_tasks.yml
@@ -1,6 +1,6 @@
 # Even though we are Resuming, we Restart the Business Interaction replication - since this
 # is reference data it is possible to do a full reload of the data and start from that point
-- name: Restart Business Interaction Replication Task
+- name: Restart Business Interaction Replication Tasks
   include_tasks: restart_business_interaction_task.yml
   when: business_interaction_task_arn is defined
 
@@ -8,20 +8,29 @@
 # Audited Interaction data replication is not dependent on it
 - name: Resume the Audited Interaction Checksum DMS CDC Replication Tasks
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_checksum_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ checksum_task_arn }}" \
         --region {{ region }}  --start-replication-task-type resume-processing
-  when: audited_interaction_checksum_task_arn is defined
+  loop: "{{ audited_interaction_checksum_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: checksum_task_arn
+  when: (audited_interaction_checksum_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
 
 - name: Resume the User and Probation Area DMS CDC Replication Tasks
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ user__task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ user_task_arn }}" \
         --region {{ region }}  --start-replication-task-type resume-processing
-  when: user__task_arn is defined
+  loop: "{{ user__task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: user_task_arn
+  when: (user__task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0
 
 - name: Resume the Audited Interaction DMS CDC Replication Tasks
   shell: |
-    aws dms start-replication-task --replication-task-arn "{{ audited_interaction_task_arn }}" \
+    aws dms start-replication-task --replication-task-arn "{{ audited_task_arn }}" \
         --region {{ region }}  --start-replication-task-type resume-processing
+  loop: "{{ audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list }}"
+  loop_control:
+    loop_var: audited_task_arn
   when:
     - audit_cdc_scn | default('') == ''
-    - audited_interaction_task_arn is defined
+    - (audited_interaction_task_arn | default([]) | map('trim') | reject('equalto', '') | list | length) > 0

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/stop_tasks.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/stop_tasks.yml
@@ -1,8 +1,24 @@
+- name: Build combined list of replication task ARNs
+  set_fact:
+    replication_task_arns: >-
+      {{
+        [
+          audited_interaction_checksum_task_arn | default([]),
+          audited_interaction_task_arn | default([]),
+          business_interaction_task_arn | default([]),
+          user__task_arn | default([])
+        ]
+        | flatten
+        | map('trim')
+        | reject('equalto', '')
+        | list
+      }}
+
 - name: Stop DMS Replication Tasks
   shell: |
     aws dms stop-replication-task --replication-task-arn "{{ replication_task_arn }}"  --region {{ region }}
   register: stop_replication
-  loop: "{{ [audited_interaction_checksum_task_arn, audited_interaction_task_arn, business_interaction_task_arn, user__task_arn] | select('defined') | list }}"
+  loop: "{{ replication_task_arns }}"
   loop_control:
     loop_var: "replication_task_arn"
   ignore_errors: true # Some of these tasks may already be stopped, so ignore errors stopping them
@@ -18,7 +34,7 @@
   until: task_status.stdout in ['stopped','ready','failed']
   retries: 60
   delay: 10
-  loop: "{{ [audited_interaction_checksum_task_arn, audited_interaction_task_arn, business_interaction_task_arn, user__task_arn] | select('defined') | list }}"
+  loop: "{{ replication_task_arns }}"
   loop_control:
     loop_var: "replication_task_arn"
   changed_when: FALSE

--- a/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/wait_for_zero_throughput.yml
+++ b/playbooks/oracle_audit_replication_management/oracle_audit_replication_management/tasks/wait_for_zero_throughput.yml
@@ -14,7 +14,8 @@
         --region {{ region }} \
        --namespace 'AWS/DMS' --period 60 --statistics Maximum \
        --dimensions Name=ReplicationInstanceIdentifier,Value={{ get_replication_instance.stdout }} \
-                    Name=ReplicationTaskIdentifier,Value={{ audited_interaction_task_arn.split(':')[-1] }} \
+                      Name=EnvironmentName,Value={{ target_environment_name }} \
+                    Name=ReplicationTaskIdentifier,Value={{ audited_interaction_task_arn[0].split(':')[-1] }} \
        --query "Datapoints[0].Maximum" --output text
   register: get_cdc_throughput_row_source
   until: (get_cdc_throughput_row_source.stdout == '0.0') or (get_cdc_throughput_row_source.stdout == 'null') or  (get_cdc_throughput_row_source.stdout == 'None')

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
@@ -4,7 +4,7 @@
 # manner
 - name: Report Start of Endpoint Testing
   debug:
-     msg: "Testing Endpoint {{ endpoint_arn }} for {{ target_environment_name.split('-') }} using Replication Instance {{ replication_instance_arn }}"
+     msg: "Testing Endpoint {{ endpoint_arn }} for {{ target_environment_name.split('-')[0] }} using Replication Instance {{ replication_instance_arn }}"
 
 - name: Start Test of DMS Endpoint {{ endpoint_arn }}
   shell: |

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
@@ -2,6 +2,10 @@
 # a test may already be in progress when we get here - ignore any error related to this,
 # otherwise start a new test so we can wait for the status to be updated in a timely
 # manner
+- name: Report Start of Endpoint Testing
+  debug:
+     msg: "Testing Endpoint {{ endpoint_arn }} using Replication Instance {{ replication_instance_arn }}"
+
 - name: Start Test of DMS Endpoint {{ endpoint_arn }}
   shell: |
     aws dms test-connection --endpoint-arn {{ endpoint_arn }} \

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
@@ -4,7 +4,7 @@
 # manner
 - name: Report Start of Endpoint Testing
   debug:
-     msg: "Testing Endpoint {{ endpoint_arn }} for {{ target_environment_name.split('-')[0] }} using Replication Instance {{ replication_instance_arn }}"
+     msg: "Testing Endpoint {{ endpoint_arn }} for {{ target_environment_name.split('-') | last }} using Replication Instance {{ replication_instance_arn }}"
 
 - name: Start Test of DMS Endpoint {{ endpoint_arn }}
   shell: |

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/test_dms_endpoints.yml
@@ -4,7 +4,7 @@
 # manner
 - name: Report Start of Endpoint Testing
   debug:
-     msg: "Testing Endpoint {{ endpoint_arn }} using Replication Instance {{ replication_instance_arn }}"
+     msg: "Testing Endpoint {{ endpoint_arn }} for {{ target_environment_name.split('-') }} using Replication Instance {{ replication_instance_arn }}"
 
 - name: Start Test of DMS Endpoint {{ endpoint_arn }}
   shell: |

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
@@ -66,7 +66,7 @@
 
 - name: Get ARN for the DMS replication instance named {{ target_environment_name.split('-')[0] }}-dms-instance
   shell: |
-    DMS_INSTANCE_IDENTIFIER="{{ target_environment_name.split('-')[0] }}-dms-instance"
+    DMS_INSTANCE_IDENTIFIER="{{ target_environment_name.split('-') | last }}-dms-instance"
     aws dms describe-replication-instances --region {{ region }} \
       --output json | jq -r --arg instance_id "$DMS_INSTANCE_IDENTIFIER" '.ReplicationInstances[] | select(.ReplicationInstanceIdentifier == $instance_id) | .ReplicationInstanceArn' | head -n1
   delegate_to: localhost

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
@@ -74,6 +74,10 @@
   changed_when: false
   register: get_replication_instance_arn
 
+- name: Report Relication Instance for this Delius Environment
+  debug:
+     msg: "Using {{ target_environment_name.split('-')[0] }}-dms-instance Replication Instance {{ get_replication_instance_arn.stdout }}"
+
 - name: Test All Endpoints Following Password Change
   include_tasks: test_dms_endpoints.yml
   loop: "{{ describe_endpoints.stdout_lines }}"

--- a/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
+++ b/playbooks/oracle_password_rotation/all_password_rotation/tasks/update_dms_endpoints.yml
@@ -64,11 +64,11 @@
     DATABASE_PASSWORD: "{{ secretsmanager_passwords_dict['account']['passwords']['delius_audit_dms_pool'] }}"
     ASM_PASSWORD: "{{ secretsmanager_passwords_dict['account']['passwords']['delius_audit_dms_pool'] }}"
 
-- name: Get ARN for the first DMS replication instance
+- name: Get ARN for the DMS replication instance named {{ target_environment_name.split('-')[0] }}-dms-instance
   shell: |
+    DMS_INSTANCE_IDENTIFIER="{{ target_environment_name.split('-')[0] }}-dms-instance"
     aws dms describe-replication-instances --region {{ region }} \
-      --query "ReplicationInstances[0].ReplicationInstanceArn" \
-      --output text
+      --output json | jq -r --arg instance_id "$DMS_INSTANCE_IDENTIFIER" '.ReplicationInstances[] | select(.ReplicationInstanceIdentifier == $instance_id) | .ReplicationInstanceArn' | head -n1
   delegate_to: localhost
   become: no
   changed_when: false


### PR DESCRIPTION
This pull request refactors the Oracle Audit Replication Management playbooks to better support multiple replication tasks of the same type, improve robustness when handling task ARNs, and enhance logging for clarity. The changes ensure that all relevant DMS replication tasks are properly handled as lists, loops are used where appropriate, and empty or undefined ARNs are filtered out to avoid errors. Several debug messages have also been added to aid troubleshooting.

**Replication Task Handling Improvements:**

* Updated all facts in `get_task_details.yml` to store replication task ARNs as lists (`stdout_lines`), ensuring support for multiple tasks of the same type. [[1]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L19-R22) [[2]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L33-R33) [[3]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L43-R43) [[4]](diffhunk://#diff-746e9f7bede20a167e4b904ae92a1207a286461a60ffd3dcff43c1a3b6bd0cd2L53-R53)
* Refactored all restart, resume, and stop task playbooks to loop over lists of ARNs, filtering out blanks, and using explicit loop variables for clarity and correctness. [[1]](diffhunk://#diff-705ee27ac3854a2a375371f300437815920371f09cbfdc4d6cc464ccef8bb4ecL7-R29) [[2]](diffhunk://#diff-9bf1beb0ee814436c9eebbd0f07a7f3226b38e77700921588e08ca6aa173933bR25-R63) [[3]](diffhunk://#diff-9bf1beb0ee814436c9eebbd0f07a7f3226b38e77700921588e08ca6aa173933bL63-R79) [[4]](diffhunk://#diff-5f386a625cccc702c6e7f3f5ffc9e72ccb2a26815583511296d995ce049e8708L3-R36) [[5]](diffhunk://#diff-85d3036b5213fd09c0aa3767fc5d581158336c39df91b2c54b59a67523664e73R1-R21) [[6]](diffhunk://#diff-85d3036b5213fd09c0aa3767fc5d581158336c39df91b2c54b59a67523664e73L21-R37)

**Logic and Robustness Enhancements:**

* Improved conditional checks in `main.yml` and related playbooks to only proceed when there are non-empty ARNs, preventing errors when no tasks are found.
* Ensured that single-ARN operations (such as client-side restarts) use the first ARN from the list, while repository-side operations loop over all ARNs.

**Logging and Debugging:**

* Added debug messages to report which endpoints and replication instances are being used during password rotation and endpoint testing, improving traceability. [[1]](diffhunk://#diff-57d059922b36e93eb91d1f4a16880bf8b8f11e5676051dc4cc773480b852c738R5-R8) [[2]](diffhunk://#diff-389b1829f6793eb97f5c23637ccbc44096cf784336bc892bc6a697db42552060L67-R80)

**Query and Command Improvements:**

* Improved the query for fetching the DMS replication instance ARN to select the correct instance by name instead of always using the first instance.
* Added environment name as a CloudWatch dimension in `wait_for_zero_throughput.yml` for more precise monitoring.