### PR TITLE
Set MIS Environment Name Correctly

### DIFF
--- a/.github/workflows/oracle-db-restore-points.yml
+++ b/.github/workflows/oracle-db-restore-points.yml
@@ -158,7 +158,7 @@ jobs:
         id: mis_exists
         working-directory: ${{ env.inventory }}
         run: |
-          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/-prod/_production_prod/')
+          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/_production_prod/')
           # Only required to check if mis_primarydb.yml Ansible inventory group vars file exists
           # to check MIS is in this environment
           if [[ -e group_vars/${environment_name}_mis_primarydb.yml ]]

--- a/.github/workflows/oracle-db-restore-points.yml
+++ b/.github/workflows/oracle-db-restore-points.yml
@@ -158,7 +158,7 @@ jobs:
         id: mis_exists
         working-directory: ${{ env.inventory }}
         run: |
-          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/_production_prod/')
+          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')
           # Only required to check if mis_primarydb.yml Ansible inventory group vars file exists
           # to check MIS is in this environment
           if [[ -e group_vars/${environment_name}_mis_primarydb.yml ]]


### PR DESCRIPTION
This pull request makes a small but important update to the environment name mapping logic in the `.github/workflows/oracle-db-restore-points.yml` workflow. The change ensures that the `prod` environment is correctly mapped to `production_prod` when constructing the `environment_name` variable.

- **Bug fix for environment mapping:**
  * Updated the `sed` command in the `mis_exists` job to map `prod` to `production_prod`, ensuring the correct environment variable is set for production deployments.