### PR TITLE
Set environment for Delius

### DIFF
--- a/.github/workflows/oracle-db-restore-points.yml
+++ b/.github/workflows/oracle-db-restore-points.yml
@@ -225,7 +225,7 @@ jobs:
       - name: Define Delius Targets
         id: definetargets
         run: |
-          delius_target=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/-prod/_production_prod/')_delius_dbs
+          delius_target=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_dbs
           echo "delius_target=${delius_target}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials


### PR DESCRIPTION
This pull request makes a small but important fix to the logic for defining Delius environment targets in the GitHub Actions workflow. The change ensures that the `prod` environment is correctly mapped to `production_prod` instead of incorrectly appending an extra underscore.

* Fixed the `sed` substitution in the `Define Delius Targets` step of `.github/workflows/oracle-db-restore-points.yml` to correctly map the `prod` environment to `production_prod`