### PR TITLE
Purge of Old GET EXTRACTS DATA Records

### DIFF
--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -113,15 +113,7 @@ jobs:
         id: definetargets
         run: |
           delius_target_primary=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_standbydb1
-          delius_target_adg=${delius_target_primary%_*}_standbydb2
-          # If no group_vars file exists for the ADG Standby assume it does
-          # not exist and use the primary host instead
-          if [[ ! -e group_vars/${delius_target_adg}.yml ]]
-          then
-            delius_target_adg=${delius_target_primary}
-          fi
           echo "delius_target_primary=${delius_target_primary}" >> $GITHUB_OUTPUT
-          echo "delius_target_adg=${delius_target_adg}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials
         id: login-aws
@@ -142,7 +134,6 @@ jobs:
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
             -e target_hosts=${{ steps.definetargets.outputs.delius_target_primary }} \
             -e delius_target_primary=${{ steps.definetargets.outputs.delius_target_primary }} \
-            -e delius_target_adg=${{ steps.definetargets.outputs.delius_target_adg }} \
             | tee /tmp/ansible_delius.log
           next_partition_high_value=$(cat /tmp/next_partition_high_value 2>/dev/null | tr -d '\n')
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -82,6 +82,7 @@ jobs:
     continue-on-error: false
     outputs:
       next_partition_high_value: ${{ steps.ansible_delius.outputs.next_partition_high_value }}
+      delius_rows_removed: ${{ steps.ansible_delius.outputs.delius_rows_removed }}
     steps:
 
       - name: Checkout hmpps-delius-operation-automation
@@ -135,6 +136,8 @@ jobs:
             | tee /tmp/ansible_delius.log
           next_partition_high_value=$(cat /tmp/next_partition_high_value 2>/dev/null | tr -d '\n')
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
+          delius_rows_removed=$(cat /tmp/delius_rows_removed 2>/dev/null | tr -d '\n')
+          echo "delius_rows_removed=${delius_rows_removed}" >> $GITHUB_OUTPUT
 
   audit-purge-mis:
     needs: [validate-parameters,audit-purge-delius]
@@ -187,4 +190,5 @@ jobs:
           $command -i $inventory \
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
             -e target_hosts=${{ needs.validate-parameters.outputs.MisTargets }} \
-            -e next_partition_high_value=${{ needs.audit-purge-delius.outputs.next_partition_high_value }}
+            -e next_partition_high_value=${{ needs.audit-purge-delius.outputs.next_partition_high_value }} \
+            -e delius_rows_removed=${{ needs.audit-purge-delius.outputs.delius_rows_removed }}

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -133,6 +133,10 @@ jobs:
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
             -e target_hosts=${{ steps.definetargets.outputs.delius_target }} \
             | tee /tmp/ansible_delius.log
+          echo "-----"
+          echo "Output:"
+          cat /tmp/ansible_delius.log
+          echo "-----"
           next_partition_high_value=$(grep -oP 'NEXT_PARTITION_HIGH_VALUE=\K[0-9]{4}-[0-9]{2}-[0-9]{2}' /tmp/ansible_delius.log | tail -1)
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -1,9 +1,6 @@
 name: "Oracle: Audit Purge GET_EXTRACTS_DATA"
 run-name: "Oracle: ${{ github.event.inputs.TargetEnvironment }}-audit-purge-get-extracts-data"
 on:
-  push:
-    branches:
-      - "DBA-1210"
   workflow_dispatch:
     inputs:
       # Note that we use, for example, "dev" here instead of "delius-core-dev"

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -131,7 +131,7 @@ jobs:
           export ANSIBLE_CONFIG=$ansible_config
           $command -i $inventory \
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
-            -e target_dbs=${{ steps.definetargets.outputs.delius_target }} \
+            -e target_hosts=${{ steps.definetargets.outputs.delius_target }} \
             | tee /tmp/ansible_delius.log
           next_partition_high_value=$(grep -oP 'NEXT_PARTITION_HIGH_VALUE=\K[0-9]{4}-[0-9]{2}-[0-9]{2}' /tmp/ansible_delius.log | tail -1)
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
@@ -186,8 +186,5 @@ jobs:
           export ANSIBLE_CONFIG=$ansible_config
           $command -i $inventory \
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
-            -e target_dbs=${{ needs.validate-parameters.outputs.MisTargets }} \
+            -e target_hosts=${{ needs.validate-parameters.outputs.MisTargets }} \
             -e next_partition_high_value=${{ needs.audit-purge-delius.outputs.next_partition_high_value }}
-          export ANSIBLE_CONFIG=$ansible_config
-          $command -i $inventory -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
-          -e target_dbs=${{ needs.validate-parameters.outputs.MisTargets  }}

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -15,7 +15,7 @@ on:
         options:
           - "dev"
           - "test"
-          - "traing"
+          - "training"
           - "stage"
           - "preprod"
           - "prod"
@@ -83,6 +83,8 @@ jobs:
       image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
     timeout-minutes: 1440
     continue-on-error: false
+    outputs:
+      next_partition_high_value: ${{ steps.ansible_delius.outputs.next_partition_high_value }}
     steps:
 
       - name: Checkout hmpps-delius-operation-automation
@@ -125,14 +127,20 @@ jobs:
           role-duration-seconds: 21600
 
       - name: Start Ansible Audit Purge for Delius
+        id: ansible_delius
         shell: bash
         run: |
+          set -o pipefail
           export ANSIBLE_CONFIG=$ansible_config
-          $command -i $inventory -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
-          -e target_dbs=${{ steps.definetargets.outputs.delius_target }} 
+          $command -i $inventory \
+            -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
+            -e target_dbs=${{ steps.definetargets.outputs.delius_target }} \
+            | tee /tmp/ansible_delius.log
+          next_partition_high_value=$(grep -oP 'NEXT_PARTITION_HIGH_VALUE=\K[0-9]{4}-[0-9]{2}-[0-9]{2}' /tmp/ansible_delius.log | tail -1)
+          echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
 
   audit-purge-mis:
-    needs: validate-parameters
+    needs: [validate-parameters,audit-purge-delius]
     if: ${{ needs.validate-parameters.outputs.MisTargets != 'none' }}
     environment: delius-mis-${{ github.event.inputs.TargetEnvironment }}-preapproved
     runs-on: ubuntu-latest
@@ -178,6 +186,11 @@ jobs:
       - name: Start Audit Purge for MIS
         shell: bash
         run: |
+          export ANSIBLE_CONFIG=$ansible_config
+          $command -i $inventory \
+            -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
+            -e target_dbs=${{ needs.validate-parameters.outputs.MisTargets }} \
+            -e next_partition_high_value=${{ needs.audit-purge-delius.outputs.next_partition_high_value }}
           export ANSIBLE_CONFIG=$ansible_config
           $command -i $inventory -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
           -e target_dbs=${{ needs.validate-parameters.outputs.MisTargets  }}

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -133,10 +133,6 @@ jobs:
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
             -e target_hosts=${{ steps.definetargets.outputs.delius_target }} \
             | tee /tmp/ansible_delius.log
-          echo "-----"
-          echo "Output:"
-          cat /tmp/ansible_delius.log
-          echo "-----"
           next_partition_high_value=$(cat /tmp/next_partition_high_value 2>/dev/null | tr -d '\n')
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
 

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -112,8 +112,16 @@ jobs:
       - name: Define Delius Targets
         id: definetargets
         run: |
-          delius_target=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_standbydb1
-          echo "delius_target=${delius_target}" >> $GITHUB_OUTPUT
+          delius_target_primary=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_standbydb1
+          delius_target_adg=${delius_target_primary%_*}_standbydb2
+          # If no group_vars file exists for the ADG Standby assume it does
+          # not exist and use the primary host instead
+          if [[ ! -e group_vars/${delius_target_adg}.yml ]]
+          then
+            delius_target_adg=${delius_target_primary}
+          fi
+          echo "delius_target_primary=${delius_target_primary}" >> $GITHUB_OUTPUT
+          echo "delius_target_adg=${delius_target_adg}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials
         id: login-aws
@@ -132,7 +140,9 @@ jobs:
           export ANSIBLE_CONFIG=$ansible_config
           $command -i $inventory \
             -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
-            -e target_hosts=${{ steps.definetargets.outputs.delius_target }} \
+            -e target_hosts=${{ steps.definetargets.outputs.delius_target_primary }} \
+            -e delius_target_primary=${{ steps.definetargets.outputs.delius_target_primary }} \
+            -e delius_target_adg=${{ steps.definetargets.outputs.delius_target_adg }} \
             | tee /tmp/ansible_delius.log
           next_partition_high_value=$(cat /tmp/next_partition_high_value 2>/dev/null | tr -d '\n')
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -112,7 +112,8 @@ jobs:
       - name: Define Delius Targets
         id: definetargets
         run: |
-          delius_target_primary=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_standbydb1
+          source "$PWD/operations/common/files/build_inventory_name.sh"
+          delius_target_primary="$(build_inventory_name "delius-core-${{ github.event.inputs.TargetEnvironment }}" "_delius_standbydb1")"
           echo "delius_target_primary=${delius_target_primary}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -137,7 +137,7 @@ jobs:
           echo "Output:"
           cat /tmp/ansible_delius.log
           echo "-----"
-          next_partition_high_value=$(grep -oP 'NEXT_PARTITION_HIGH_VALUE=\K[0-9]{4}-[0-9]{2}-[0-9]{2}' /tmp/ansible_delius.log | tail -1)
+          next_partition_high_value=$(cat /tmp/next_partition_high_value 2>/dev/null | tr -d '\n')
           echo "next_partition_high_value=${next_partition_high_value}" >> $GITHUB_OUTPUT
 
   audit-purge-mis:

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -111,6 +111,7 @@ jobs:
 
       - name: Define Delius Targets
         id: definetargets
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
           delius_target_primary="$(build_inventory_name "delius-core-${{ github.event.inputs.TargetEnvironment }}" "_delius_standbydb1")"

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -1,0 +1,183 @@
+name: "Oracle: Audit Purge GET_EXTRACTS_DATA"
+run-name: "Oracle: ${{ github.event.inputs.TargetEnvironment }}-audit-purge-get-extracts-data"
+on:
+  push:
+    branches:
+      - "DBA-1210"
+  workflow_dispatch:
+    inputs:
+      # Note that we use, for example, "dev" here instead of "delius-core-dev"
+      # since we need to include both Delius & MIS environments in the same rollback.
+      TargetEnvironment:
+        description: "Target environment"
+        required: true
+        type: choice
+        options:
+          - "dev"
+          - "test"
+          - "traing"
+          - "stage"
+          - "preprod"
+          - "prod"
+      SourceCodeVersion:
+        description: "Source version for the hmpps-delius-operation-automation. Enter a pull request, branch, commit ID, tag, or reference."
+        type: string
+        default: "main"
+      SourceConfigVersion:
+        description: "Source version for the modernisation-platform-configuration-management. Enter a pull request, branch, commit ID, tag, or reference."
+        type: string
+        default: "main"
+
+env:
+  ansible_config: operations/playbooks/ansible.cfg
+  command: ansible-playbook operations/playbooks/oracle_db_audit_purge_get_extracts_data/playbook.yml
+  inventory: inventory/ansible
+
+# Allow permissions on repository and docker image and OIDC token
+permissions:
+  contents: read
+  packages: read
+  id-token: write
+
+jobs:          
+  validate-parameters:
+    environment: delius-core-dev-preapproved # Choose any environment as its only used for validating parameters
+    runs-on: ubuntu-latest
+    outputs:
+      MisTargets: ${{ steps.mis_exists.outputs.mis_targets }}
+    continue-on-error: false
+    steps:
+
+      - name: Checkout modernisation-platform-configuration-management
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ministryofjustice/modernisation-platform-configuration-management
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            ansible/hosts
+            ansible/group_vars
+          path: inventory
+          ref: ${{ github.event.inputs.SourceConfigVersion }}
+          fetch-depth: 0
+
+      - name: Check MIS Exists In Environment
+        id: mis_exists
+        working-directory: ${{ env.inventory }}
+        run: |
+          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')
+          # Only required to check if mis_primarydb.yml Ansible inventory group vars file exists
+          # to check MIS is in this environment
+          if [[ -e group_vars/${environment_name}_mis_primarydb.yml ]]
+          then
+            mis_targets=${environment_name}_mis_primarydb
+          else
+            mis_targets=none
+          fi
+          echo "mis_targets=${mis_targets}" >> $GITHUB_OUTPUT
+
+  audit-purge-delius:
+    needs: validate-parameters
+    environment: delius-core-${{ github.event.inputs.TargetEnvironment }}-preapproved
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
+    timeout-minutes: 1440
+    continue-on-error: false
+    steps:
+
+      - name: Checkout hmpps-delius-operation-automation
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            playbooks/oracle_db_audit_purge_get_extracts_data
+            playbooks/ansible.cfg
+            common/*
+          path: operations
+          ref: ${{ github.event.inputs.SourceCodeVersion }}
+          fetch-depth: 0
+
+      - name: Checkout modernisation-platform-configuration-management
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ministryofjustice/modernisation-platform-configuration-management
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            ansible/hosts
+            ansible/group_vars
+          path: inventory
+          ref: ${{ github.event.inputs.SourceConfigVersion }}
+          fetch-depth: 0
+
+      - name: Define Delius Targets
+        id: definetargets
+        run: |
+          delius_target=environment_name_delius_core_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')_delius_standbydb1
+          echo "delius_target=${delius_target}" >> $GITHUB_OUTPUT
+
+      - name: Configure AWS Credentials
+        id: login-aws
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          aws-region: "eu-west-2"
+          role-duration-seconds: 21600
+
+      - name: Start Ansible Audit Purge for Delius
+        shell: bash
+        run: |
+          export ANSIBLE_CONFIG=$ansible_config
+          $command -i $inventory -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
+          -e target_dbs=${{ steps.definetargets.outputs.delius_target }} 
+
+  audit-purge-mis:
+    needs: validate-parameters
+    if: ${{ needs.validate-parameters.outputs.MisTargets != 'none' }}
+    environment: delius-mis-${{ github.event.inputs.TargetEnvironment }}-preapproved
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
+    timeout-minutes: 1440
+    continue-on-error: false
+    steps:
+
+      - name: Checkout modernisation-platform-configuration-management
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          repository: ministryofjustice/modernisation-platform-configuration-management
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            ansible/hosts
+            ansible/group_vars
+          path: inventory
+          ref: ${{ github.event.inputs.SourceConfigVersion }}
+          fetch-depth: 0
+  
+      - name: Checkout hmpps-delius-operation-automation
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            playbooks/oracle_db_audit_purge_get_extracts_data
+            playbooks/ansible.cfg
+            common/*
+          path: operations
+          ref: ${{ github.event.inputs.SourceCodeVersion }}
+          fetch-depth: 0
+
+      - name: Configure AWS Credentials
+        id: login-aws
+        uses: aws-actions/configure-aws-credentials@7474bc4690e29a8392af63c5b98e7449536d5c3a # v4.3.1
+        with:
+          role-to-assume: "arn:aws:iam::${{ vars.AWS_ACCOUNT_ID }}:role/modernisation-platform-oidc-cicd"
+          role-session-name: "hmpps-delius-operational-automation-${{ github.run_number }}"
+          role-duration-seconds: 21600
+          aws-region: "eu-west-2"
+
+      - name: Start Audit Purge for MIS
+        shell: bash
+        run: |
+          export ANSIBLE_CONFIG=$ansible_config
+          $command -i $inventory -e ansible_aws_ssm_bucket_name=${{ vars.ANSIBLE_AWS_SSM_BUCKET_NAME }} \
+          -e target_dbs=${{ needs.validate-parameters.outputs.MisTargets  }}

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -57,16 +57,28 @@ jobs:
           ref: ${{ github.event.inputs.SourceConfigVersion }}
           fetch-depth: 0
 
+      - name: Checkout hmpps-delius-operational-automation
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+        with:
+          sparse-checkout-cone-mode: false
+          sparse-checkout: |
+            common/files/build_inventory_name.sh
+          path: operations
+          ref: ${{ github.event.inputs.SourceCodeVersion }}
+          fetch-depth: 0
+
       - name: Check MIS Exists In Environment
         id: mis_exists
+        shell: bash
         working-directory: ${{ env.inventory }}
         run: |
-          environment_name=environment_name_delius_mis_$(echo ${{ github.event.inputs.TargetEnvironment }} | sed 's/dev/development_dev/;s/test/test_test/;s/training/test_training/;s/stage/preproduction_stage/;s/^preprod$/preproduction_preprod/;s/^prod$/production_prod/')
+          source "$GITHUB_WORKSPACE/operations/common/files/build_inventory_name.sh"
+          environment_name="$(build_inventory_name "delius-mis-${{ github.event.inputs.TargetEnvironment }}" "_mis_primarydb")"
           # Only required to check if mis_primarydb.yml Ansible inventory group vars file exists
           # to check MIS is in this environment
-          if [[ -e group_vars/${environment_name}_mis_primarydb.yml ]]
+          if [[ -e group_vars/${environment_name}.yml ]]
           then
-            mis_targets=${environment_name}_mis_primarydb
+            mis_targets=${environment_name}
           else
             mis_targets=none
           fi

--- a/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
+++ b/.github/workflows/oracle-db-audit-purge-get-extracts-data.yml
@@ -114,7 +114,7 @@ jobs:
         shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
-          delius_target_primary="$(build_inventory_name "delius-core-${{ github.event.inputs.TargetEnvironment }}" "_delius_standbydb1")"
+          delius_target_primary="$(build_inventory_name "delius-core-${{ github.event.inputs.TargetEnvironment }}" "_delius_primarydb")"
           echo "delius_target_primary=${delius_target_primary}" >> $GITHUB_OUTPUT
 
       - name: Configure AWS Credentials

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
@@ -21,7 +21,7 @@ DECLARE
     l_schema_name           VARCHAR2(128) := '${SCHEMA_NAME}';
     l_table_name            VARCHAR2(128) := '${TABLE_NAME}';
     l_rows_deleted          NUMBER;
-    l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
+    l_business_interaction_id ${SCHEMA_NAME}.business_interaction.business_interaction_id%TYPE;
 BEGIN
 
     -- Validate HIGH_VALUE format is YYYY-MM-DD
@@ -32,7 +32,7 @@ BEGIN
     -- Get the ID for the GET_EXTRACT_DATA business interaction type
     SELECT business_interaction_id
     INTO   l_business_interaction_id
-    FROM   delius_app_schema.business_interaction
+    FROM   ${SCHEMA_NAME}.business_interaction
     WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
 
     DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Deleting rows before '||l_high_value);

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
@@ -1,0 +1,53 @@
+#!/bin/bash
+
+# This script is only used for MIS data prior to January 2015 as before
+# this date it does not use monthly partitioning as used by Delius.
+# Fortunately the volumes of these really old partitions are low so we can
+# just delete the data rather than using partition exchange.
+
+. ~/.bash_profile
+
+# HIGH_VALUE format is YYYY-MM-DD
+HIGH_VALUE=${1:?Usage: exchange_partition.sh <high_value> <schema_name> <table_name>}
+SCHEMA_NAME=${2:?Usage: exchange_partition.sh <high_value> <schema_name> <table_name>}
+TABLE_NAME=${3:?Usage: exchange_partition.sh <high_value> <schema_name> <table_name>}
+
+sqlplus -s /nolog <<EOSQL
+connect / as sysdba
+
+SET SERVEROUT ON
+DECLARE
+    l_high_value            VARCHAR2(30) :=  '${HIGH_VALUE}';
+    l_schema_name           VARCHAR2(128) := '${SCHEMA_NAME}';
+    l_table_name            VARCHAR2(128) := '${TABLE_NAME}';
+    l_rows_deleted          NUMBER;
+    l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
+BEGIN
+
+    -- Validate HIGH_VALUE format is YYYY-MM-DD
+    IF NOT REGEXP_LIKE(l_high_value, '^\d{4}-\d{2}-\d{2}$') THEN
+        RAISE_APPLICATION_ERROR(-20001, 'HIGH_VALUE must be in YYYY-MM-DD format, got: ' || l_high_value);
+    END IF;
+
+    -- Get the ID for the GET_EXTRACT_DATA business interaction type
+    SELECT business_interaction_id
+    INTO   l_business_interaction_id
+    FROM   delius_app_schema.business_interaction
+    WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
+
+    DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Deleting rows before '||l_high_value);
+
+    EXECUTE IMMEDIATE
+        'DELETE FROM ' || l_schema_name || '.' || l_table_name || ' ' ||
+        'WHERE date_time < DATE ''' || l_high_value || '''' ;
+
+    l_rows_deleted := SQL%ROWCOUNT;
+
+    DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
+
+    DBMS_OUTPUT.PUT_LINE('ROWS_DELETED='||l_rows_deleted);
+END;
+/
+
+EXIT
+EOSQL

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/delete_rows.sh
@@ -39,7 +39,9 @@ BEGIN
 
     EXECUTE IMMEDIATE
         'DELETE FROM ' || l_schema_name || '.' || l_table_name || ' ' ||
-        'WHERE date_time < DATE ''' || l_high_value || '''' ;
+        'WHERE date_time < DATE ''' || l_high_value || ''' ' ||
+        'AND business_interaction_id = :1'
+    USING l_business_interaction_id;
 
     l_rows_deleted := SQL%ROWCOUNT;
 

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -133,28 +133,11 @@ BEGIN
     -- Drop the staging table (now contains rows to be removed)
     EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
 
-    -- Record successfully processed partition names as a CSV list in the table comment
+    -- Track the highest partition purged so far; overwrite on each successful exchange
     IF l_schema_name = 'DELIUS_APP_SCHEMA' THEN
-        DECLARE
-            l_comment  VARCHAR2(4000);
-            l_prologue CONSTANT VARCHAR2(200) := 'Partitions purged of GET_EXTRACTS_DATA rows by exchange_partition: ';
-        BEGIN
-            SELECT NVL(comments, '')
-            INTO   l_comment
-            FROM   dba_tab_comments
-            WHERE  owner      = l_schema_name
-            AND    table_name = l_table_name;
-
-            IF l_comment LIKE l_prologue || '%' THEN
-                l_comment := l_comment || ',' || l_partition_name;
-            ELSE
-                l_comment := l_prologue || l_partition_name;
-            END IF;
-
-            EXECUTE IMMEDIATE
-                'COMMENT ON TABLE ' || l_schema_name || '.' || l_table_name ||
-                ' IS ''' || REPLACE(l_comment, '''', '''''') || '''';
-        END;
+        EXECUTE IMMEDIATE
+            'COMMENT ON TABLE ' || l_schema_name || '.' || l_table_name ||
+            ' IS ''Highest partition purged of GET_EXTRACTS_DATA rows by exchange_partition: ' || l_partition_name || '''';
     END IF;
 
     DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -1,0 +1,140 @@
+#!/bin/bash
+
+. ~/.bash_profile
+
+PARTITION_NAME=${1:?Usage: exchange_partition.sh <partition_name> <compress_for>}
+COMPRESS_FOR=${2:?Usage: exchange_partition.sh <partition_name> <compress_for>}
+
+sqlplus -s /nolog <<EOSQL
+connect / as sysdba
+
+SET SERVEROUT ON
+DECLARE
+    l_partition_name VARCHAR2(128) := '${PARTITION_NAME}';
+    l_compress_for          VARCHAR2(30)  := '${COMPRESS_FOR}';
+    l_rows_kept             NUMBER;
+    l_rows_before           NUMBER;
+    l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
+    l_partition_bytes_before NUMBER;
+    l_partition_bytes_after  NUMBER;
+BEGIN
+
+    -- Get the ID for the GET_EXTRACT_DATA business interaction type
+    SELECT business_interaction_id
+    INTO   l_business_interaction_id
+    FROM   delius_app_schema.business_interaction
+    WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
+
+    DBMS_APPLICATION_INFO.SET_MODULE(
+        module_name => 'exchange_partition',
+        action_name => 'Initializing: ' || l_partition_name
+    );
+
+    DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Creating exchange table');
+
+    -- Record partition size before exchange
+    SELECT NVL(SUM(bytes), 0)
+    INTO   l_partition_bytes_before
+    FROM   dba_segments
+    WHERE  owner          = 'DELIUS_APP_SCHEMA'
+    AND    segment_name   = 'AUDITED_INTERACTION'
+    AND    partition_name = l_partition_name;
+
+    -- Record row count before exchange
+    EXECUTE IMMEDIATE
+        'SELECT COUNT(*) FROM delius_app_schema.audited_interaction PARTITION (' || l_partition_name || ')'
+    INTO l_rows_before;
+
+    -- Drop staging table if it exists from a previous failed run
+    BEGIN
+        EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+    EXCEPTION
+        WHEN OTHERS THEN
+            IF SQLCODE != -942 THEN RAISE; END IF; -- -942 = table or view does not exist
+    END;
+
+    -- Create exchange table with matching structure and storage properties
+    -- FOR EXCHANGE WITH TABLE (Oracle 12c+) ensures full compatibility for partition exchange
+    EXECUTE IMMEDIATE
+        'CREATE TABLE delius_app_schema.z_audited_interaction_xchg ' ||
+        'FOR EXCHANGE WITH TABLE delius_app_schema.audited_interaction';
+
+    -- Restore the partition's original compression before inserting so that
+    -- the incoming data is stored in the same format as the source partition.
+    -- FOR EXCHANGE inherits the table default, which may differ from the partition.
+    IF l_compress_for != 'NONE' THEN
+        EXECUTE IMMEDIATE
+            'ALTER TABLE delius_app_schema.z_audited_interaction_xchg ' ||
+            'COMPRESS ' || l_compress_for;
+    END IF;
+
+    -- PCTFREE=0: the exchange table is write-once (no subsequent UPDATEs),
+    -- so no free space needs to be reserved in each block.
+    EXECUTE IMMEDIATE
+        'ALTER TABLE delius_app_schema.z_audited_interaction_xchg PCTFREE 0';
+
+    DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Populating exchange table');
+
+    -- Populate staging table with all rows except BUSINESS_INTERACTION_ID = l_business_interaction_id
+    EXECUTE IMMEDIATE
+        'INSERT /*+ APPEND */ INTO delius_app_schema.z_audited_interaction_xchg ' ||
+        'SELECT * FROM delius_app_schema.audited_interaction PARTITION (' || l_partition_name || ') ' ||
+        'WHERE business_interaction_id != ' || l_business_interaction_id;
+
+    l_rows_kept := SQL%ROWCOUNT;
+    COMMIT;
+
+    DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Exchanging partition');
+
+    -- Exchange the partition with the staging table.
+    -- After the exchange:
+    --   the partition holds only the rows kept in the staging table (BID != l_business_interaction_id)
+    --   z_audited_interaction_xchg holds the original partition rows (including BID = l_business_interaction_id)
+    -- WITHOUT VALIDATION is safe here because all retained rows were already in
+    -- this partition and therefore already satisfy its key bounds.
+    EXECUTE IMMEDIATE
+        'ALTER TABLE delius_app_schema.audited_interaction ' ||
+        'EXCHANGE PARTITION ' || l_partition_name || ' ' ||
+        'WITH TABLE delius_app_schema.z_audited_interaction_xchg ' ||
+        'WITHOUT VALIDATION';
+
+    DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Dropping exchange table');
+
+    -- Record partition size after exchange (before dropping the exchange table)
+    SELECT NVL(SUM(bytes), 0)
+    INTO   l_partition_bytes_after
+    FROM   dba_segments
+    WHERE  owner          = 'DELIUS_APP_SCHEMA'
+    AND    segment_name   = 'AUDITED_INTERACTION'
+    AND    partition_name = l_partition_name;
+
+    -- Drop the staging table (now contains rows to be removed)
+    EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+
+    DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
+
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_STATUS=SUCCESS');
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_NAME=' || l_partition_name);
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_BEFORE=' || l_rows_before);
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_AFTER=' || l_rows_kept);
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_REMOVED=' || (l_rows_before - l_rows_kept));
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_BEFORE=' || l_partition_bytes_before);
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_AFTER=' || l_partition_bytes_after);
+    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_REDUCTION=' || (l_partition_bytes_before - l_partition_bytes_after));
+
+EXCEPTION
+    WHEN OTHERS THEN
+        DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
+        DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_STATUS=FAILED');
+        DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ERROR=' || SQLERRM);
+        BEGIN
+            EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+        EXCEPTION
+            WHEN OTHERS THEN NULL;
+        END;
+        RAISE;
+END;
+/
+
+EXIT
+EOSQL

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -2,8 +2,10 @@
 
 . ~/.bash_profile
 
-PARTITION_NAME=${1:?Usage: exchange_partition.sh <partition_name> <compress_for>}
-COMPRESS_FOR=${2:?Usage: exchange_partition.sh <partition_name> <compress_for>}
+PARTITION_NAME=${1:?Usage: exchange_partition.sh <partition_name> <compress_for> <schema_name> <table_name>}
+COMPRESS_FOR=${2:?Usage: exchange_partition.sh <partition_name> <compress_for> <schema_name> <table_name>}
+SCHEMA_NAME=${3:?Usage: exchange_partition.sh <partition_name> <compress_for> <schema_name> <table_name>}
+TABLE_NAME=${4:?Usage: exchange_partition.sh <partition_name> <compress_for> <schema_name> <table_name>}
 
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
@@ -11,6 +13,8 @@ connect / as sysdba
 SET SERVEROUT ON
 DECLARE
     l_partition_name VARCHAR2(128) := '${PARTITION_NAME}';
+    l_schema_name           VARCHAR2(128) := '${SCHEMA_NAME}';
+    l_table_name            VARCHAR2(128) := '${TABLE_NAME}';
     l_compress_for          VARCHAR2(30)  := '${COMPRESS_FOR}';
     l_rows_kept             NUMBER;
     l_rows_before           NUMBER;
@@ -36,18 +40,18 @@ BEGIN
     SELECT NVL(SUM(bytes), 0)
     INTO   l_partition_bytes_before
     FROM   dba_segments
-    WHERE  owner          = 'DELIUS_APP_SCHEMA'
-    AND    segment_name   = 'AUDITED_INTERACTION'
+    WHERE  owner          = l_schema_name
+    AND    segment_name   = l_table_name
     AND    partition_name = l_partition_name;
 
     -- Record row count before exchange
     EXECUTE IMMEDIATE
-        'SELECT COUNT(*) FROM delius_app_schema.audited_interaction PARTITION (' || l_partition_name || ')'
+        'SELECT COUNT(*) FROM ' || l_schema_name || '.' || l_table_name || ' PARTITION (' || l_partition_name || ')'
     INTO l_rows_before;
 
     -- Drop staging table if it exists from a previous failed run
     BEGIN
-        EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+        EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
     EXCEPTION
         WHEN OTHERS THEN
             IF SQLCODE != -942 THEN RAISE; END IF; -- -942 = table or view does not exist
@@ -56,29 +60,29 @@ BEGIN
     -- Create exchange table with matching structure and storage properties
     -- FOR EXCHANGE WITH TABLE (Oracle 12c+) ensures full compatibility for partition exchange
     EXECUTE IMMEDIATE
-        'CREATE TABLE delius_app_schema.z_audited_interaction_xchg ' ||
-        'FOR EXCHANGE WITH TABLE delius_app_schema.audited_interaction';
+        'CREATE TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg ' ||
+        'FOR EXCHANGE WITH TABLE ' || l_schema_name || '.' || l_table_name;
 
     -- Restore the partition's original compression before inserting so that
     -- the incoming data is stored in the same format as the source partition.
     -- FOR EXCHANGE inherits the table default, which may differ from the partition.
     IF l_compress_for != 'NONE' THEN
         EXECUTE IMMEDIATE
-            'ALTER TABLE delius_app_schema.z_audited_interaction_xchg ' ||
+            'ALTER TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg ' ||
             'COMPRESS ' || l_compress_for;
     END IF;
 
     -- PCTFREE=0: the exchange table is write-once (no subsequent UPDATEs),
     -- so no free space needs to be reserved in each block.
     EXECUTE IMMEDIATE
-        'ALTER TABLE delius_app_schema.z_audited_interaction_xchg PCTFREE 0';
+        'ALTER TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PCTFREE 0';
 
     DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Populating exchange table');
 
     -- Populate staging table with all rows except BUSINESS_INTERACTION_ID = l_business_interaction_id
     EXECUTE IMMEDIATE
-        'INSERT /*+ APPEND */ INTO delius_app_schema.z_audited_interaction_xchg ' ||
-        'SELECT * FROM delius_app_schema.audited_interaction PARTITION (' || l_partition_name || ') ' ||
+        'INSERT /*+ APPEND */ INTO ' || l_schema_name || '.z_' || l_table_name || '_xchg ' ||
+        'SELECT * FROM ' || l_schema_name || '.' || l_table_name || ' PARTITION (' || l_partition_name || ') ' ||
         'WHERE business_interaction_id != ' || l_business_interaction_id;
 
     l_rows_kept := SQL%ROWCOUNT;
@@ -89,13 +93,13 @@ BEGIN
     -- Exchange the partition with the staging table.
     -- After the exchange:
     --   the partition holds only the rows kept in the staging table (BID != l_business_interaction_id)
-    --   z_audited_interaction_xchg holds the original partition rows (including BID = l_business_interaction_id)
+    --   z_<table>_xchg holds the original partition rows (including BID = l_business_interaction_id)
     -- WITHOUT VALIDATION is safe here because all retained rows were already in
     -- this partition and therefore already satisfy its key bounds.
     EXECUTE IMMEDIATE
-        'ALTER TABLE delius_app_schema.audited_interaction ' ||
+        'ALTER TABLE ' || l_schema_name || '.' || l_table_name || ' ' ||
         'EXCHANGE PARTITION ' || l_partition_name || ' ' ||
-        'WITH TABLE delius_app_schema.z_audited_interaction_xchg ' ||
+        'WITH TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg ' ||
         'WITHOUT VALIDATION';
 
     DBMS_APPLICATION_INFO.SET_ACTION(action_name => 'Dropping exchange table');
@@ -104,12 +108,12 @@ BEGIN
     SELECT NVL(SUM(bytes), 0)
     INTO   l_partition_bytes_after
     FROM   dba_segments
-    WHERE  owner          = 'DELIUS_APP_SCHEMA'
-    AND    segment_name   = 'AUDITED_INTERACTION'
+    WHERE  owner          = l_schema_name
+    AND    segment_name   = l_table_name
     AND    partition_name = l_partition_name;
 
     -- Drop the staging table (now contains rows to be removed)
-    EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+    EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
 
     DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
 
@@ -128,7 +132,7 @@ EXCEPTION
         DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_STATUS=FAILED');
         DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ERROR=' || SQLERRM);
         BEGIN
-            EXECUTE IMMEDIATE 'DROP TABLE delius_app_schema.z_audited_interaction_xchg PURGE';
+            EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
         EXCEPTION
             WHEN OTHERS THEN NULL;
         END;

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -10,6 +10,8 @@ TABLE_NAME=${4:?Usage: exchange_partition.sh <partition_name> <compress_for> <sc
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
 
+WHENEVER SQLERROR EXIT FAILURE
+
 SET SERVEROUT ON
 DECLARE
     l_partition_name VARCHAR2(128) := '${PARTITION_NAME}';
@@ -26,7 +28,7 @@ BEGIN
     -- Get the ID for the GET_EXTRACT_DATA business interaction type
     SELECT business_interaction_id
     INTO   l_business_interaction_id
-    FROM   delius_app_schema.business_interaction
+    FROM   ${SCHEMA_NAME}.business_interaction
     WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
 
     DBMS_APPLICATION_INFO.SET_MODULE(

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -20,7 +20,7 @@ DECLARE
     l_compress_for          VARCHAR2(30)  := '${COMPRESS_FOR}';
     l_rows_kept             NUMBER;
     l_rows_before           NUMBER;
-    l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
+    l_business_interaction_id ${SCHEMA_NAME}.business_interaction.business_interaction_id%TYPE;
     l_partition_bytes_before NUMBER;
     l_partition_bytes_after  NUMBER;
 BEGIN

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -23,6 +23,8 @@ DECLARE
     l_business_interaction_id ${SCHEMA_NAME}.business_interaction.business_interaction_id%TYPE;
     l_partition_bytes_before NUMBER;
     l_partition_bytes_after  NUMBER;
+    l_table_bytes_before     NUMBER;
+    l_table_bytes_after      NUMBER;
 BEGIN
 
     -- Get the ID for the GET_EXTRACT_DATA business interaction type
@@ -45,6 +47,13 @@ BEGIN
     WHERE  owner          = l_schema_name
     AND    segment_name   = l_table_name
     AND    partition_name = l_partition_name;
+
+    -- Record total table size before exchange
+    SELECT NVL(SUM(bytes), 0)
+    INTO   l_table_bytes_before
+    FROM   dba_segments
+    WHERE  owner        = l_schema_name
+    AND    segment_name = l_table_name;
 
     -- Record row count before exchange
     EXECUTE IMMEDIATE
@@ -114,25 +123,35 @@ BEGIN
     AND    segment_name   = l_table_name
     AND    partition_name = l_partition_name;
 
+    -- Record total table size after exchange
+    SELECT NVL(SUM(bytes), 0)
+    INTO   l_table_bytes_after
+    FROM   dba_segments
+    WHERE  owner        = l_schema_name
+    AND    segment_name = l_table_name;
+
     -- Drop the staging table (now contains rows to be removed)
     EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
 
     DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
 
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_STATUS=SUCCESS');
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_NAME=' || l_partition_name);
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_BEFORE=' || l_rows_before);
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_AFTER=' || l_rows_kept);
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ROWS_REMOVED=' || (l_rows_before - l_rows_kept));
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_BEFORE=' || l_partition_bytes_before);
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_AFTER=' || l_partition_bytes_after);
-    DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_BYTES_REDUCTION=' || (l_partition_bytes_before - l_partition_bytes_after));
+    DBMS_OUTPUT.PUT_LINE('PARTITION_STATUS=SUCCESS');
+    DBMS_OUTPUT.PUT_LINE('PARTITION_NAME=' || l_partition_name);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_ROWS_BEFORE=' || l_rows_before);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_ROWS_AFTER=' || l_rows_kept);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_ROWS_REMOVED=' || (l_rows_before - l_rows_kept));
+    DBMS_OUTPUT.PUT_LINE('PARTITION_BYTES_BEFORE=' || l_partition_bytes_before);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_BYTES_AFTER=' || l_partition_bytes_after);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_BYTES_REDUCTION=' || (l_partition_bytes_before - l_partition_bytes_after));
+    DBMS_OUTPUT.PUT_LINE('TABLE_BYTES_BEFORE=' || l_table_bytes_before);
+    DBMS_OUTPUT.PUT_LINE('TABLE_BYTES_AFTER=' || l_table_bytes_after);
+    DBMS_OUTPUT.PUT_LINE('TABLE_BYTES_REDUCTION=' || (l_table_bytes_before - l_table_bytes_after));
 
 EXCEPTION
     WHEN OTHERS THEN
         DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
-        DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_STATUS=FAILED');
-        DBMS_OUTPUT.PUT_LINE('EXCHANGE_PARTITION_ERROR=' || SQLERRM);
+        DBMS_OUTPUT.PUT_LINE('PARTITION_STATUS=FAILED');
+        DBMS_OUTPUT.PUT_LINE('PARTITION_ERROR=' || SQLERRM);
         BEGIN
             EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
         EXCEPTION

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/exchange_partition.sh
@@ -133,6 +133,30 @@ BEGIN
     -- Drop the staging table (now contains rows to be removed)
     EXECUTE IMMEDIATE 'DROP TABLE ' || l_schema_name || '.z_' || l_table_name || '_xchg PURGE';
 
+    -- Record successfully processed partition names as a CSV list in the table comment
+    IF l_schema_name = 'DELIUS_APP_SCHEMA' THEN
+        DECLARE
+            l_comment  VARCHAR2(4000);
+            l_prologue CONSTANT VARCHAR2(200) := 'Partitions purged of GET_EXTRACTS_DATA rows by exchange_partition: ';
+        BEGIN
+            SELECT NVL(comments, '')
+            INTO   l_comment
+            FROM   dba_tab_comments
+            WHERE  owner      = l_schema_name
+            AND    table_name = l_table_name;
+
+            IF l_comment LIKE l_prologue || '%' THEN
+                l_comment := l_comment || ',' || l_partition_name;
+            ELSE
+                l_comment := l_prologue || l_partition_name;
+            END IF;
+
+            EXECUTE IMMEDIATE
+                'COMMENT ON TABLE ' || l_schema_name || '.' || l_table_name ||
+                ' IS ''' || REPLACE(l_comment, '''', '''''') || '''';
+        END;
+    END IF;
+
     DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
 
     DBMS_OUTPUT.PUT_LINE('PARTITION_STATUS=SUCCESS');

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -1,0 +1,116 @@
+#!/bin/bash
+
+. ~/.bash_profile
+
+sqlplus -s /nolog <<EOSQL
+connect / as sysdba
+
+SET SERVEROUT ON
+DECLARE
+    l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
+    l_dummy               NUMBER;
+    l_high_value_raw      VARCHAR2(255);
+    l_high_value          DATE;
+    l_compress_for        VARCHAR2(30);
+    l_partition_count     NUMBER;
+    l_partition_num  NUMBER := 0;
+    l_rindex         BINARY_INTEGER := DBMS_APPLICATION_INFO.set_session_longops_nohint;
+    l_slno           BINARY_INTEGER;
+BEGIN
+
+    DBMS_APPLICATION_INFO.SET_MODULE(
+        module_name => 'get_next_partition',
+        action_name => 'Initializing'
+    );
+
+    -- Count partitions to support progress reporting
+    SELECT COUNT(*)
+    INTO   l_partition_count
+    FROM   all_tab_partitions
+    WHERE  table_name  = 'AUDITED_INTERACTION'
+    AND    table_owner = 'DELIUS_APP_SCHEMA';
+
+    -- Get the ID for the GET_EXTRACT_DATA business interaction type
+    SELECT business_interaction_id
+    INTO   l_business_interaction_id
+    FROM   delius_app_schema.business_interaction
+    WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
+
+    FOR p IN (
+        SELECT partition_name
+        FROM   all_tab_partitions
+        WHERE  table_name = 'AUDITED_INTERACTION'
+        AND    table_owner = 'DELIUS_APP_SCHEMA'
+        ORDER BY partition_position
+    )
+    LOOP
+        l_partition_num := l_partition_num + 1;
+
+        -- Fetch HIGH_VALUE (LONG -> VARCHAR2 implicit conversion in PL/SQL SELECT INTO)
+        -- and COMPRESS_FOR for the partition compression type
+        SELECT high_value, compress_for
+        INTO   l_high_value_raw, l_compress_for
+        FROM   all_tab_partitions
+        WHERE  table_name      = 'AUDITED_INTERACTION'
+        AND    table_owner     = 'DELIUS_APP_SCHEMA'
+        AND    partition_name  = p.partition_name;
+
+        -- Extract the date portion from the HIGH_VALUE string
+        -- e.g. TIMESTAMP' 2024-03-01 00:00:00' -> 2024-03-01
+        l_high_value := TO_DATE(
+            REGEXP_SUBSTR(l_high_value_raw, '\d{4}-\d{2}-\d{2}'),
+            'YYYY-MM-DD'
+        );
+
+        CONTINUE WHEN l_high_value < DATE '2015-01-01';
+
+        DBMS_APPLICATION_INFO.SET_ACTION(
+            action_name => l_partition_num || '/' || l_partition_count ||
+                           ' ' || p.partition_name || ' (' || TO_CHAR(l_high_value, 'YYYY-MM-DD') || ')'
+        );
+
+        DBMS_APPLICATION_INFO.SET_SESSION_LONGOPS(
+            rindex      => l_rindex,
+            slno        => l_slno,
+            op_name     => 'get_next_partition',
+            target_desc => 'DELIUS_APP_SCHEMA.AUDITED_INTERACTION',
+            sofar       => l_partition_num,
+            totalwork   => l_partition_count,
+            units       => 'partitions'
+        );
+
+        BEGIN
+            EXECUTE IMMEDIATE
+                'SELECT 1 ' ||
+                'FROM DELIUS_APP_SCHEMA.AUDITED_INTERACTION PARTITION (' || p.partition_name || ') ' ||
+                'WHERE BUSINESS_INTERACTION_ID = :1 AND ROWNUM = 1'
+            INTO l_dummy
+            USING l_business_interaction_id;
+
+            DBMS_APPLICATION_INFO.SET_MODULE(
+                module_name => NULL,
+                action_name => NULL
+            );
+            DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_ID=' || p.partition_name);
+            DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_HIGH_VALUE=' || TO_CHAR(l_high_value, 'YYYY-MM-DD'));
+            DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_COMPRESS_FOR=' || NVL(l_compress_for, 'NONE'));
+            RETURN;
+
+        EXCEPTION
+            WHEN NO_DATA_FOUND THEN
+                NULL; -- try next partition
+        END;
+    END LOOP;
+
+    DBMS_APPLICATION_INFO.SET_MODULE(
+        module_name => NULL,
+        action_name => NULL
+    );
+    DBMS_OUTPUT.PUT_LINE(
+        'No partitions contain GET_EXTRACTS_DATA'
+    );
+END;
+/
+
+EXIT
+EOSQL

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -2,6 +2,9 @@
 
 . ~/.bash_profile
 
+# USE_PARALLEL=1 enables parallel query (recommended when running on ADG standby)
+USE_PARALLEL=${1:-0}
+
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
 
@@ -22,6 +25,12 @@ BEGIN
         module_name => 'get_next_partition',
         action_name => 'Initializing'
     );
+
+    -- Enable parallel query when running on ADG standby for better performance.
+    -- PARALLEL_THREADS_PER_CPU * CPU_COUNT determines the default degree.
+    IF '${USE_PARALLEL}' = '1' THEN
+        EXECUTE IMMEDIATE 'ALTER SESSION FORCE PARALLEL QUERY PARALLEL DEFAULT';
+    END IF;
 
     -- Count partitions to support progress reporting
     SELECT COUNT(*)

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -64,8 +64,6 @@ BEGIN
             'YYYY-MM-DD'
         );
 
-        CONTINUE WHEN l_high_value < DATE '2015-01-01';
-
         DBMS_APPLICATION_INFO.SET_ACTION(
             action_name => l_partition_num || '/' || l_partition_count ||
                            ' ' || p.partition_name || ' (' || TO_CHAR(l_high_value, 'YYYY-MM-DD') || ')'

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -27,9 +27,9 @@ BEGIN
     );
 
     -- Enable parallel query when running on ADG standby for better performance.
-    -- PARALLEL_THREADS_PER_CPU * CPU_COUNT determines the default degree.
+    -- Omitting PARALLEL <n> lets Oracle use PARALLEL_THREADS_PER_CPU * CPU_COUNT.
     IF '${USE_PARALLEL}' = '1' THEN
-        EXECUTE IMMEDIATE 'ALTER SESSION FORCE PARALLEL QUERY PARALLEL DEFAULT';
+        EXECUTE IMMEDIATE 'ALTER SESSION FORCE PARALLEL QUERY';
     END IF;
 
     -- Count partitions to support progress reporting

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -2,8 +2,6 @@
 
 . ~/.bash_profile
 
-# USE_PARALLEL=1 enables parallel query (recommended when running on ADG standby)
-USE_PARALLEL=${1:-0}
 
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
@@ -26,11 +24,6 @@ BEGIN
         action_name => 'Initializing'
     );
 
-    -- Enable parallel query when running on ADG standby for better performance.
-    -- Omitting PARALLEL <n> lets Oracle use PARALLEL_THREADS_PER_CPU * CPU_COUNT.
-    IF '${USE_PARALLEL}' = '1' THEN
-        EXECUTE IMMEDIATE 'ALTER SESSION FORCE PARALLEL QUERY';
-    END IF;
 
     -- Count partitions to support progress reporting
     SELECT COUNT(*)

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -6,6 +6,8 @@
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
 
+WHENEVER SQLERROR EXIT FAILURE
+
 SET SERVEROUT ON
 DECLARE
     l_business_interaction_id delius_app_schema.business_interaction.business_interaction_id%TYPE;
@@ -61,7 +63,7 @@ BEGIN
         -- If no previous partition processed started from the beginning
         WHEN NO_DATA_FOUND 
         THEN
-           l_skip_before_partition := 0;
+           l_skip_before_position := 0;
     END;
 
     FOR p IN (

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_next_partition.sh
@@ -12,9 +12,11 @@ DECLARE
     l_dummy               NUMBER;
     l_high_value_raw      VARCHAR2(255);
     l_high_value          DATE;
-    l_compress_for        VARCHAR2(30);
-    l_partition_count     NUMBER;
-    l_partition_num  NUMBER := 0;
+    l_compress_for                VARCHAR2(30);
+    l_partition_count             NUMBER;
+    l_partition_num               NUMBER := 0;
+    l_highest_processed_name      VARCHAR2(128);
+    l_skip_before_position        NUMBER := 0;
     l_rindex         BINARY_INTEGER := DBMS_APPLICATION_INFO.set_session_longops_nohint;
     l_slno           BINARY_INTEGER;
 BEGIN
@@ -38,11 +40,36 @@ BEGIN
     FROM   delius_app_schema.business_interaction
     WHERE  UPPER(description) = 'GET_EXTRACTS_DATA';
 
+    -- Resume after the highest partition already processed (recorded in the table comment)
+    -- (This is simply a performance optimisation to avoid us having to check
+    --  all the partitions from the beginning each time we run)
+    BEGIN
+        SELECT REGEXP_SUBSTR(comments, '[^ ]+$')
+        INTO   l_highest_processed_name
+        FROM   dba_tab_comments
+        WHERE  owner      = 'DELIUS_APP_SCHEMA'
+        AND    table_name = 'AUDITED_INTERACTION'
+        AND    comments   LIKE 'Highest partition purged of GET_EXTRACTS_DATA rows by exchange_partition: %';
+
+        SELECT partition_position
+        INTO   l_skip_before_position
+        FROM   all_tab_partitions
+        WHERE  table_owner    = 'DELIUS_APP_SCHEMA'
+        AND    table_name     = 'AUDITED_INTERACTION'
+        AND    partition_name = l_highest_processed_name;
+    EXCEPTION
+        -- If no previous partition processed started from the beginning
+        WHEN NO_DATA_FOUND 
+        THEN
+           l_skip_before_partition := 0;
+    END;
+
     FOR p IN (
         SELECT partition_name
         FROM   all_tab_partitions
-        WHERE  table_name = 'AUDITED_INTERACTION'
-        AND    table_owner = 'DELIUS_APP_SCHEMA'
+        WHERE  table_name      = 'AUDITED_INTERACTION'
+        AND    table_owner     = 'DELIUS_APP_SCHEMA'
+        AND    partition_position > l_skip_before_position
         ORDER BY partition_position
     )
     LOOP
@@ -94,6 +121,7 @@ BEGIN
             DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_ID=' || p.partition_name);
             DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_HIGH_VALUE=' || TO_CHAR(l_high_value, 'YYYY-MM-DD'));
             DBMS_OUTPUT.PUT_LINE('NEXT_PARTITION_COMPRESS_FOR=' || NVL(l_compress_for, 'NONE'));
+            DBMS_OUTPUT.PUT_LINE('SEARCH_RESUMED_AFTER=' || NVL(l_highest_processed_name, 'NONE'));
             RETURN;
 
         EXCEPTION

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_partition_for_high_value.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_partition_for_high_value.sh
@@ -1,0 +1,60 @@
+#!/bin/bash
+
+. ~/.bash_profile
+
+HIGH_VALUE_DATE=${1:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name>}
+SCHEMA_NAME=${2:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name>}
+
+sqlplus -s /nolog <<EOSQL
+connect / as sysdba
+
+SET SERVEROUT ON
+DECLARE
+    l_target_date  DATE          := TO_DATE('${HIGH_VALUE_DATE}', 'YYYY-MM-DD');
+    l_schema_name  VARCHAR2(128) := UPPER('${SCHEMA_NAME}');
+    l_high_value   VARCHAR2(255);
+    l_high_value_date DATE;
+BEGIN
+
+    DBMS_APPLICATION_INFO.SET_MODULE(
+        module_name => 'get_partition_for_high_value',
+        action_name => 'Searching: ' || '${HIGH_VALUE_DATE}'
+    );
+
+    FOR p IN (
+        SELECT partition_name
+        FROM   all_tab_partitions
+        WHERE  table_name  = 'AUDITED_INTERACTION'
+        AND    table_owner = l_schema_name
+        ORDER BY partition_position
+    )
+    LOOP
+        -- Fetch HIGH_VALUE (LONG -> VARCHAR2 implicit conversion in PL/SQL SELECT INTO)
+        SELECT high_value
+        INTO   l_high_value
+        FROM   all_tab_partitions
+        WHERE  table_name     = 'AUDITED_INTERACTION'
+        AND    table_owner    = l_schema_name
+        AND    partition_name = p.partition_name;
+
+        l_high_value_date := TO_DATE(
+            REGEXP_SUBSTR(l_high_value, '\d{4}-\d{2}-\d{2}'),
+            'YYYY-MM-DD'
+        );
+
+        IF l_high_value_date = l_target_date THEN
+            DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
+            DBMS_OUTPUT.PUT_LINE('PARTITION_NAME=' || p.partition_name);
+            RETURN;
+        END IF;
+    END LOOP;
+
+    DBMS_APPLICATION_INFO.SET_MODULE(module_name => NULL, action_name => NULL);
+    DBMS_OUTPUT.PUT_LINE('PARTITION_NAME=');
+    DBMS_OUTPUT.PUT_LINE('PARTITION_NOT_FOUND=No partition has HIGH_VALUE ' || '${HIGH_VALUE_DATE}');
+
+END;
+/
+
+EXIT
+EOSQL

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_partition_for_high_value.sh
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/files/get_partition_for_high_value.sh
@@ -2,8 +2,9 @@
 
 . ~/.bash_profile
 
-HIGH_VALUE_DATE=${1:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name>}
-SCHEMA_NAME=${2:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name>}
+HIGH_VALUE_DATE=${1:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name> <table_name>}
+SCHEMA_NAME=${2:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name> <table_name>}
+TABLE_NAME=${3:?Usage: get_partition_for_high_value.sh <high_value_date YYYY-MM-DD> <schema_name> <table_name>}
 
 sqlplus -s /nolog <<EOSQL
 connect / as sysdba
@@ -12,6 +13,7 @@ SET SERVEROUT ON
 DECLARE
     l_target_date  DATE          := TO_DATE('${HIGH_VALUE_DATE}', 'YYYY-MM-DD');
     l_schema_name  VARCHAR2(128) := UPPER('${SCHEMA_NAME}');
+    l_table_name   VARCHAR2(128) := UPPER('${TABLE_NAME}');
     l_high_value   VARCHAR2(255);
     l_high_value_date DATE;
 BEGIN
@@ -24,7 +26,7 @@ BEGIN
     FOR p IN (
         SELECT partition_name
         FROM   all_tab_partitions
-        WHERE  table_name  = 'AUDITED_INTERACTION'
+        WHERE  table_name  = l_table_name
         AND    table_owner = l_schema_name
         ORDER BY partition_position
     )
@@ -33,7 +35,7 @@ BEGIN
         SELECT high_value
         INTO   l_high_value
         FROM   all_tab_partitions
-        WHERE  table_name     = 'AUDITED_INTERACTION'
+        WHERE  table_name     = l_table_name
         AND    table_owner    = l_schema_name
         AND    partition_name = p.partition_name;
 

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -43,9 +43,14 @@
       when: next_partition_high_value != 'none'
 
     - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
-      script: exchange_partition.sh {{ next_partition_id }} {{ next_partition_compress_for }}
+      script: exchange_partition.sh {{ next_partition_id }} {{ next_partition_compress_for }} DELIUS_APP_SCHEMA AUDITED_INTERACTION
       register: exchange_partition_output
       when: next_partition_id != 'none'
+
+    - name: Log Exchange Partition Statistics
+      debug:
+        msg: "{{ exchange_partition_output.stdout }}"
+      when: exchange_partition_output is not skipped
 
     - name: Set Exchange Partition Variables
       set_fact:

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -1,0 +1,81 @@
+- name: Get Primary Database Type And Environment
+  set_fact:
+    database_type: "{{ group_names | select('match','.*_primarydb') | list | first | regex_replace('^.*_(.*)_primarydb', '\\1') }}"
+    database_environment: "{{ group_names | select('match','.*_primarydb') | list | first | regex_replace('^(.*)_primarydb', '\\1') }}"
+  when: database_primary_sid is defined
+
+- name: Get Standby Database Type And Environment
+  set_fact:
+    database_type: "{{ group_names | select('match','.*_standbydb[12]') | list | first | regex_replace('^.*_(.*)_standbydb[12]', '\\1') }}"
+    database_environment: "{{ group_names | select('match','.*_standbydb[12]') | list | first | regex_replace('^(.*)_standbydb[12]', '\\1') }}"
+  when: not database_primary_sid is defined
+
+- name: Show info
+  debug:
+     msg: "Running against the {{ database_type }} database in the {{ database_environment }} environment"
+
+- name: Purge Data from Delius
+  when: database_type == 'delius'
+  block:
+      
+    - name: Get Next Partition to Process
+      script: get_next_partition.sh
+      register: get_next_partition_output
+      changed_when: false
+
+    - name: Set Next Partition Variables
+      set_fact:
+        next_partition_id: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | first | regex_replace('^NEXT_PARTITION_ID=', '') }}"
+        next_partition_high_value: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_HIGH_VALUE=') | first | regex_replace('^NEXT_PARTITION_HIGH_VALUE=', '') }}"
+        next_partition_compress_for: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_COMPRESS_FOR=') | first | regex_replace('^NEXT_PARTITION_COMPRESS_FOR=', '') }}"
+      when: get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | list | length > 0
+
+    - name: Report Action to Do
+      debug:
+        msg: "Purging GET_EXTRACTS_DATA from the partition to {{ next_partition_high_value }}"
+
+    - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
+      script: exchange_partition.sh {{ next_partition_id }} {{ next_partition_compress_for }}
+      register: exchange_partition_output
+      when: next_partition_id is defined
+
+    - name: Set Exchange Partition Variables
+      set_fact:
+        exchange_partition_status: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_STATUS=') | first | regex_replace('^EXCHANGE_PARTITION_STATUS=', '') }}"
+        exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_ROWS_AFTER=') | first | regex_replace('^EXCHANGE_PARTITION_ROWS_AFTER=', '') }}"
+      when: exchange_partition_output is not skipped
+
+    - name: Broadcast next_partition_high_value to all hosts
+      set_fact:
+        next_partition_high_value: "{{ next_partition_high_value }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      loop: "{{ groups['all'] }}"
+      when: next_partition_high_value is defined
+
+- name: Lookup Data in MIS
+  when: 
+     - database_type == 'mis'
+     - next_partition_high_value is not null
+  block:
+
+    - name: Get Corresponding Partition in NDMIS_CDC_SUBSCRIBER
+      script: get_partition_for_high_value.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER
+      register: get_ndmis_cdc_subscriber_partition
+      changed_when: false
+
+    - name: Set NDMIS_CDC_SUBSCRIBER Partition Variables
+      set_fact:
+        ndmis_cdc_subscriber_partition_name: "{{ get_ndmis_cdc_subscriber_partition.stdout_lines | select('match', '^PARTITION_NAME=') | first | regex_replace('^PARTITION_NAME=', '') }}"
+        ndmis_cdc_subscriber_partition_not_found: "{{ get_ndmis_cdc_subscriber_partition.stdout_lines | select('match', '^PARTITION_NOT_FOUND=') | map('regex_replace', '^PARTITION_NOT_FOUND=', '') | list | first | default('') }}"
+
+    - name: Report NDMIS_CDC_SUBSCRIBER Partition Result
+      debug:
+        msg: >-
+          {% if ndmis_cdc_subscriber_partition_name %}
+          Found partition {{ ndmis_cdc_subscriber_partition_name }} in NDMIS_CDC_SUBSCRIBER for HIGH_VALUE {{ next_partition_high_value }}
+          {% else %}
+          {{ ndmis_cdc_subscriber_partition_not_found }}
+          {% endif %}
+
+

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -82,7 +82,7 @@
   block:
 
     - name: Get Corresponding Partition in NDMIS_CDC_SUBSCRIBER
-      script: get_partition_for_high_value.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER
+      script: get_partition_for_high_value.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
       register: get_ndmis_cdc_subscriber_partition
       changed_when: false
 
@@ -100,4 +100,24 @@
           {{ ndmis_cdc_subscriber_partition_not_found }}
           {% endif %}
 
+    # Very old data (before 2015) is not partitioned monthly in MIS so we simply delete the unwanted rows
+    - name: Delete to Remove Old GET_EXTRACTS_DATA Rows
+      script: delete_rows.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
+      register: exchange_partition_output
+      when: 
+         - next_partition_id != 'none'
+         - next_partition_high_value != 'none'
+         - next_partition_high_value < '2015-01-01'
 
+    - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
+      script: exchange_partition.sh {{ ndmis_cdc_subscriber_partition_name }} NONE NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
+      register: mis_exchange_partition_output
+      when: 
+         - next_partition_id != 'none'
+         - next_partition_high_value != 'none'
+         - next_partition_high_value >= '2015-01-01'
+
+    - name: Log Exchange Partition Statistics
+      debug:
+        msg: "{{ mis_exchange_partition_output.stdout }}"
+      when: mis_exchange_partition_output is not skipped

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -54,8 +54,8 @@
 
     - name: Set Exchange Partition Variables
       set_fact:
-        exchange_partition_status: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_STATUS=') | first | regex_replace('^EXCHANGE_PARTITION_STATUS=', '') }}"
-        exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_ROWS_AFTER=') | first | regex_replace('^EXCHANGE_PARTITION_ROWS_AFTER=', '') }}"
+        exchange_partition_status: "{{ exchange_partition_output.stdout_lines | select('match', '^PARTITION_STATUS=') | first | regex_replace('^PARTITION_STATUS=', '') }}"
+        exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^PARTITION_ROWS_AFTER=') | first | regex_replace('^PARTITION_ROWS_AFTER=', '') }}"
       when: exchange_partition_output is not skipped
 
     - name: Broadcast next_partition_high_value to all hosts
@@ -75,10 +75,15 @@
       run_once: true
       when: next_partition_high_value != 'none'
 
-- name: Purge Data in NDMIS_CDC_SUBSCRIBER
+- name: Purge Data in MIS Schemas
   include_tasks: purge_mis_data.yml
   vars:
-     schema_name: NDMIS_CDC_SUBSCRIBER
+     schema_name: "{{ schema }}"
+  loop:
+     - NDMIS_CDC_SUBSCRIBER
+     - NDMIS_DATA
+  loop_control:
+     loop_var: schema
   when: 
      - database_type == 'mis'
      - next_partition_high_value | default('none') != 'none'

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -23,6 +23,10 @@
       register: get_next_partition_output
       changed_when: false
 
+    - name: Log Get Next Partition Output
+      debug:
+        msg: "{{ get_next_partition_output.stdout }}"
+
     - name: Set Next Partition Variables
       set_fact:
         next_partition_id: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | first | regex_replace('^NEXT_PARTITION_ID=', '') }}"

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -28,6 +28,9 @@
       become: true
       become_user: oracle
 
+    - debug:
+        var: get_next_partition_output.stdout_lines
+
     - name: Set Next Partition Variables
       set_fact:
         next_partition_id: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | first | regex_replace('^NEXT_PARTITION_ID=', '') }}"

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -30,14 +30,22 @@
         next_partition_compress_for: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_COMPRESS_FOR=') | first | regex_replace('^NEXT_PARTITION_COMPRESS_FOR=', '') }}"
       when: get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | list | length > 0
 
+    - name: Set Next Partition Variables to Default (None Found)
+      set_fact:
+        next_partition_id: 'none'
+        next_partition_high_value: 'none'
+        next_partition_compress_for: 'none'
+      when: get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | list | length == 0
+
     - name: Report Action to Do
       debug:
         msg: "Purging GET_EXTRACTS_DATA from the partition to {{ next_partition_high_value }}"
+      when: next_partition_high_value != 'none'
 
     - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
       script: exchange_partition.sh {{ next_partition_id }} {{ next_partition_compress_for }}
       register: exchange_partition_output
-      when: next_partition_id is defined
+      when: next_partition_id != 'none'
 
     - name: Set Exchange Partition Variables
       set_fact:
@@ -51,7 +59,7 @@
       delegate_to: "{{ item }}"
       delegate_facts: true
       loop: "{{ groups['all'] }}"
-      when: next_partition_high_value is defined
+      when: next_partition_high_value != 'none'
 
     - name: Write next_partition_high_value to controller for workflow extraction
       local_action:
@@ -60,12 +68,12 @@
         dest: /tmp/next_partition_high_value
       become: false
       run_once: true
-      when: next_partition_high_value is defined
+      when: next_partition_high_value != 'none'
 
 - name: Lookup Data in MIS
   when: 
      - database_type == 'mis'
-     - next_partition_high_value is not null
+     - next_partition_high_value | default('none') != 'none'
   block:
 
     - name: Get Corresponding Partition in NDMIS_CDC_SUBSCRIBER

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -105,7 +105,6 @@
       script: delete_rows.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
       register: exchange_partition_output
       when: 
-         - next_partition_id != 'none'
          - next_partition_high_value != 'none'
          - next_partition_high_value < '2015-01-01'
 
@@ -113,7 +112,6 @@
       script: exchange_partition.sh {{ ndmis_cdc_subscriber_partition_name }} NONE NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
       register: mis_exchange_partition_output
       when: 
-         - next_partition_id != 'none'
          - next_partition_high_value != 'none'
          - next_partition_high_value >= '2015-01-01'
 

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -75,47 +75,10 @@
       run_once: true
       when: next_partition_high_value != 'none'
 
-- name: Lookup Data in MIS
+- name: Purge Data in NDMIS_CDC_SUBSCRIBER
+  include_tasks: purge_mis_data.yml
+  vars:
+     schema_name: NDMIS_CDC_SUBSCRIBER
   when: 
      - database_type == 'mis'
      - next_partition_high_value | default('none') != 'none'
-  block:
-
-    - name: Get Corresponding Partition in NDMIS_CDC_SUBSCRIBER
-      script: get_partition_for_high_value.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
-      register: get_ndmis_cdc_subscriber_partition
-      changed_when: false
-
-    - name: Set NDMIS_CDC_SUBSCRIBER Partition Variables
-      set_fact:
-        ndmis_cdc_subscriber_partition_name: "{{ get_ndmis_cdc_subscriber_partition.stdout_lines | select('match', '^PARTITION_NAME=') | first | regex_replace('^PARTITION_NAME=', '') }}"
-        ndmis_cdc_subscriber_partition_not_found: "{{ get_ndmis_cdc_subscriber_partition.stdout_lines | select('match', '^PARTITION_NOT_FOUND=') | map('regex_replace', '^PARTITION_NOT_FOUND=', '') | list | first | default('') }}"
-
-    - name: Report NDMIS_CDC_SUBSCRIBER Partition Result
-      debug:
-        msg: >-
-          {% if ndmis_cdc_subscriber_partition_name %}
-          Found partition {{ ndmis_cdc_subscriber_partition_name }} in NDMIS_CDC_SUBSCRIBER for HIGH_VALUE {{ next_partition_high_value }}
-          {% else %}
-          {{ ndmis_cdc_subscriber_partition_not_found }}
-          {% endif %}
-
-    # Very old data (before 2015) is not partitioned monthly in MIS so we simply delete the unwanted rows
-    - name: Delete to Remove Old GET_EXTRACTS_DATA Rows
-      script: delete_rows.sh {{ next_partition_high_value }} NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
-      register: exchange_partition_output
-      when: 
-         - next_partition_high_value != 'none'
-         - next_partition_high_value < '2015-01-01'
-
-    - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
-      script: exchange_partition.sh {{ ndmis_cdc_subscriber_partition_name }} NONE NDMIS_CDC_SUBSCRIBER Z_AUDITED_INTERACTION
-      register: mis_exchange_partition_output
-      when: 
-         - next_partition_high_value != 'none'
-         - next_partition_high_value >= '2015-01-01'
-
-    - name: Log Exchange Partition Statistics
-      debug:
-        msg: "{{ mis_exchange_partition_output.stdout }}"
-      when: mis_exchange_partition_output is not skipped

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -45,14 +45,6 @@
         exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_ROWS_AFTER=') | first | regex_replace('^EXCHANGE_PARTITION_ROWS_AFTER=', '') }}"
       when: exchange_partition_output is not skipped
 
-    - name: Broadcast next_partition_high_value to all hosts
-      set_fact:
-        next_partition_high_value: "{{ next_partition_high_value }}"
-      delegate_to: "{{ item }}"
-      delegate_facts: true
-      loop: "{{ groups['all'] }}"
-      when: next_partition_high_value is defined
-
 - name: Lookup Data in MIS
   when: 
      - database_type == 'mis'

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -19,14 +19,9 @@
   block:
       
     - name: Get Next Partition to Process
-      script: >-
-        get_next_partition.sh
-        {{ '1' if (delius_target_adg is defined and delius_target_adg != delius_target_primary) else '0' }}
+      script: get_next_partition.sh
       register: get_next_partition_output
       changed_when: false
-      delegate_to: "{{ groups[delius_target_adg | default(delius_target_primary)][0] }}"
-      become: true
-      become_user: oracle
 
     - name: Set Next Partition Variables
       set_fact:

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -58,6 +58,7 @@
         module: ansible.builtin.copy
         content: "{{ next_partition_high_value }}"
         dest: /tmp/next_partition_high_value
+      become: false
       run_once: true
       when: next_partition_high_value is defined
 

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -28,9 +28,6 @@
       become: true
       become_user: oracle
 
-    - debug:
-        var: get_next_partition_output.stdout_lines
-
     - name: Set Next Partition Variables
       set_fact:
         next_partition_id: "{{ get_next_partition_output.stdout_lines | select('match', '^NEXT_PARTITION_ID=') | first | regex_replace('^NEXT_PARTITION_ID=', '') }}"

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -56,11 +56,13 @@
       set_fact:
         exchange_partition_status: "{{ exchange_partition_output.stdout_lines | select('match', '^PARTITION_STATUS=') | first | regex_replace('^PARTITION_STATUS=', '') }}"
         exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^PARTITION_ROWS_AFTER=') | first | regex_replace('^PARTITION_ROWS_AFTER=', '') }}"
+        delius_rows_removed: "{{ exchange_partition_output.stdout_lines | select('match', '^PARTITION_ROWS_REMOVED=') | first | regex_replace('^PARTITION_ROWS_REMOVED=', '') }}"
       when: exchange_partition_output is not skipped
 
     - name: Broadcast next_partition_high_value to all hosts
       set_fact:
         next_partition_high_value: "{{ next_partition_high_value }}"
+        delius_rows_removed: "{{ delius_rows_removed | default('0') }}"
       delegate_to: "{{ item }}"
       delegate_facts: true
       loop: "{{ groups['all'] }}"
@@ -74,6 +76,15 @@
       become: false
       run_once: true
       when: next_partition_high_value != 'none'
+
+    - name: Write delius_rows_removed to controller for workflow extraction
+      local_action:
+        module: ansible.builtin.copy
+        content: "{{ delius_rows_removed }}"
+        dest: /tmp/delius_rows_removed
+      become: false
+      run_once: true
+      when: delius_rows_removed is defined
 
 - name: Purge Data in MIS Schemas
   include_tasks: purge_mis_data.yml

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -19,9 +19,14 @@
   block:
       
     - name: Get Next Partition to Process
-      script: get_next_partition.sh
+      script: >-
+        get_next_partition.sh
+        {{ '1' if (delius_target_adg is defined and delius_target_adg != delius_target_primary) else '0' }}
       register: get_next_partition_output
       changed_when: false
+      delegate_to: "{{ groups[delius_target_adg | default(delius_target_primary)][0] }}"
+      become: true
+      become_user: oracle
 
     - name: Set Next Partition Variables
       set_fact:

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/main.yml
@@ -45,6 +45,22 @@
         exchange_partition_rows_kept: "{{ exchange_partition_output.stdout_lines | select('match', '^EXCHANGE_PARTITION_ROWS_AFTER=') | first | regex_replace('^EXCHANGE_PARTITION_ROWS_AFTER=', '') }}"
       when: exchange_partition_output is not skipped
 
+    - name: Broadcast next_partition_high_value to all hosts
+      set_fact:
+        next_partition_high_value: "{{ next_partition_high_value }}"
+      delegate_to: "{{ item }}"
+      delegate_facts: true
+      loop: "{{ groups['all'] }}"
+      when: next_partition_high_value is defined
+
+    - name: Write next_partition_high_value to controller for workflow extraction
+      local_action:
+        module: ansible.builtin.copy
+        content: "{{ next_partition_high_value }}"
+        dest: /tmp/next_partition_high_value
+      run_once: true
+      when: next_partition_high_value is defined
+
 - name: Lookup Data in MIS
   when: 
      - database_type == 'mis'

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
@@ -37,3 +37,19 @@
   debug:
     msg: "{{ mis_exchange_partition_output.stdout }}"
   when: mis_exchange_partition_output is not skipped
+
+- name: Set MIS Exchange Partition Variables
+  set_fact:
+    mis_rows_removed: "{{ mis_exchange_partition_output.stdout_lines | select('match', '^PARTITION_ROWS_REMOVED=') | first | regex_replace('^PARTITION_ROWS_REMOVED=', '') }}"
+  when: mis_exchange_partition_output is not skipped
+
+- name: Assert MIS and Delius rows removed match
+  assert:
+    that:
+      - mis_rows_removed | int == delius_rows_removed | int
+    fail_msg: >-
+      Row count mismatch: {{ schema_name }} removed {{ mis_rows_removed }} rows
+      but Delius removed {{ delius_rows_removed }} rows for partition HIGH_VALUE {{ next_partition_high_value }}
+    success_msg: >-
+      Row counts match: both Delius and {{ schema_name }} removed {{ mis_rows_removed }} rows
+  when: mis_exchange_partition_output is not skipped

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
@@ -20,14 +20,14 @@
 
 # Very old data (before 2015) is not partitioned monthly in MIS so we simply delete the unwanted rows
 - name: Delete to Remove Old GET_EXTRACTS_DATA Rows
-  script: delete_rows.sh {{ next_partition_high_value }} {{ schema_name }} Z_AUDITED_INTERACTION
+  script: delete_rows.sh {{ next_partition_high_value }} {{ schema_name }} AUDITED_INTERACTION
   register: exchange_partition_output
   when: 
       - next_partition_high_value != 'none'
       - next_partition_high_value <= '2015-01-01'
 
 - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
-  script: exchange_partition.sh {{ mis_partition_name }} NONE {{ schema_name }} Z_AUDITED_INTERACTION
+  script: exchange_partition.sh {{ mis_partition_name }} NONE {{ schema_name }} AUDITED_INTERACTION
   register: mis_exchange_partition_output
   when: 
       - next_partition_high_value != 'none'

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
@@ -1,0 +1,39 @@
+
+- name: Get Corresponding Partition in {{ schema_name }}
+  script: get_partition_for_high_value.sh {{ next_partition_high_value }} {{ schema_name }} Z_AUDITED_INTERACTION
+  register: get_mis_partition
+  changed_when: false
+
+- name: Set {{ schema_name }} Partition Variables
+  set_fact:
+    mis_partition_name: "{{ get_mis_partition.stdout_lines | select('match', '^PARTITION_NAME=') | first | regex_replace('^PARTITION_NAME=', '') }}"
+    mis_partition_not_found: "{{ get_mis_partition.stdout_lines | select('match', '^PARTITION_NOT_FOUND=') | map('regex_replace', '^PARTITION_NOT_FOUND=', '') | list | first | default('') }}"
+
+- name: Report {{ schema_name }} Partition Result
+  debug:
+    msg: >-
+      {% if mis_partition_name %}
+      Found partition {{ mis_partition_name }} in {{ schema_name }} for HIGH_VALUE {{ next_partition_high_value }}
+      {% else %}
+      {{ mis_partition_not_found }}
+      {% endif %}
+
+# Very old data (before 2015) is not partitioned monthly in MIS so we simply delete the unwanted rows
+- name: Delete to Remove Old GET_EXTRACTS_DATA Rows
+  script: delete_rows.sh {{ next_partition_high_value }} {{ schema_name }} Z_AUDITED_INTERACTION
+  register: exchange_partition_output
+  when: 
+      - next_partition_high_value != 'none'
+      - next_partition_high_value < '2015-01-01'
+
+- name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
+  script: exchange_partition.sh {{ mis_partition_name }} NONE {{ schema_name }} Z_AUDITED_INTERACTION
+  register: mis_exchange_partition_output
+  when: 
+      - next_partition_high_value != 'none'
+      - next_partition_high_value >= '2015-01-01'
+
+- name: Log Exchange Partition Statistics
+  debug:
+    msg: "{{ mis_exchange_partition_output.stdout }}"
+  when: mis_exchange_partition_output is not skipped

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/oracle_db_audit_purge_get_extracts_data/tasks/purge_mis_data.yml
@@ -24,14 +24,14 @@
   register: exchange_partition_output
   when: 
       - next_partition_high_value != 'none'
-      - next_partition_high_value < '2015-01-01'
+      - next_partition_high_value <= '2015-01-01'
 
 - name: Exchange Partition to Remove GET_EXTRACTS_DATA Rows
   script: exchange_partition.sh {{ mis_partition_name }} NONE {{ schema_name }} Z_AUDITED_INTERACTION
   register: mis_exchange_partition_output
   when: 
       - next_partition_high_value != 'none'
-      - next_partition_high_value >= '2015-01-01'
+      - next_partition_high_value > '2015-01-01'
 
 - name: Log Exchange Partition Statistics
   debug:

--- a/playbooks/oracle_db_audit_purge_get_extracts_data/playbook.yml
+++ b/playbooks/oracle_db_audit_purge_get_extracts_data/playbook.yml
@@ -1,0 +1,7 @@
+---
+- hosts: "{{ target_hosts }}"
+  gather_facts: no
+  become: yes
+  become_user: oracle
+  roles:
+    - oracle_db_audit_purge_get_extracts_data


### PR DESCRIPTION
This pull request introduces a new GitHub Actions workflow and a set of supporting shell scripts to automate the purging of Oracle database audit data related to the `GET_EXTRACTS_DATA` business interaction. The workflow coordinates purging for both Delius and MIS environments, and provides progress tracking and error handling. The key changes are summarized below.

**New Workflow for Oracle Audit Purge:**

* Added `.github/workflows/oracle-db-audit-purge-get-extracts-data.yml` to orchestrate the audit purge process for Delius and MIS environments, including parameter validation, environment selection, and coordination between Delius and MIS jobs. The workflow supports multiple environments and versions, and uses Ansible playbooks for execution.

**Supporting Shell Scripts for Oracle Partition Management:**

* Added `exchange_partition.sh` to perform partition exchange operations in Oracle, efficiently removing rows related to `GET_EXTRACTS_DATA` by swapping out partition data, with detailed tracking of space and row counts before and after the operation.
* Added `delete_rows.sh` to delete rows for `GET_EXTRACTS_DATA` directly from pre-2015 MIS partitions (these use a different partitioning scheme), with validation and reporting of the number of rows deleted.
* Added `get_next_partition.sh` to identify the next partition in the Delius `AUDITED_INTERACTION` table that contains `GET_EXTRACTS_DATA` rows, supporting resumable operation and progress reporting.
* Added `get_partition_for_high_value.sh` to map a given `HIGH_VALUE` date to its corresponding partition name in a specified schema and table, facilitating targeted partition operations.