### PR TITLE
Raise an error and send a slack message if the backup validation sche…

### DIFF
--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -30,6 +30,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.SourceCodeVersion || 'main' }}
           fetch-depth: 0
 
+      - name: Validate Backup Schedule JSON
+        run: jq empty operations/.github/workflows/oracle-db-validate-backups-schedule.json
+
       - name: Filter Validate Schedule
         id: filter-validate-schedule
         run: |
@@ -69,3 +72,32 @@ jobs:
     with:
       TargetEnvironment: ${{ matrix.TargetEnvironment }}
       TargetHost: ${{ matrix.TargetHost }}
+
+  # If the GHA fails during calculation of the scheduling matrix we will not have configured
+  # any specific environment to use yet, so we default to running the failure notification from
+  # the development OEM environment (this is arbitrary)
+  setup-notification-failure-slack:
+    if: failure()
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
+    needs: [prepare-run-matrix]
+    environment: "hmpps-oem-development-preapproved"
+    permissions:
+       id-token: write
+    steps:
+
+      - name: Checkout Local Repo to get Composite Action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Send Slack Failure Notification
+        id: foreground_slack_notification
+        uses: ./.github/actions/send-slack-notification
+        env:
+            AWS_ACCOUNT_ID: "${{ vars.AWS_ACCOUNT_ID }}"
+        with:
+          Emoji: ":github-red:"
+          TextHeader: "Backup Validation Job Scheduling Failure"
+          TextBody: ":cross-red: Backup Validation job could not be scheduled"
+          TargetEnvironment: "GHA(Scheduling)"
+          JobName: "prepare-run-matrix"

--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -77,7 +77,7 @@ jobs:
   # any specific environment to use yet, so we default to running the failure notification from
   # the development OEM environment (this is arbitrary)
   setup-notification-failure-slack:
-    if: failure()
+    if: ${{ always() && needs.prepare-run-matrix.result == 'failure' }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0

--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -101,4 +101,5 @@ jobs:
           TextHeader: "Backup Validation Job Scheduling Failure"
           TextBody: ":cross-red: Backup Validation job could not be scheduled"
           TargetEnvironment: "GHA(Scheduling)"
+          TargetHost: "unknown"
           JobName: "prepare-run-matrix"

--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -84,7 +84,8 @@ jobs:
     needs: [prepare-run-matrix]
     environment: "hmpps-oem-development-preapproved"
     permissions:
-       id-token: write
+      contents: read
+      id-token: write
     steps:
 
       - name: Checkout Local Repo to get Composite Action


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for validating Oracle DB backup schedules. The main changes improve validation checks and enhance failure notification handling, ensuring issues in scheduling are promptly surfaced.

**Validation Improvements:**

* Added a step to validate the `oracle-db-validate-backups-schedule.json` file using `jq`, ensuring the backup schedule JSON is well-formed before proceeding.

**Failure Notification Enhancements:**

* Introduced a new job, `setup-notification-failure-slack`, which triggers if the workflow fails during the scheduling matrix calculation. This job sends a Slack notification from the development OEM environment to alert about scheduling failures, ensuring visibility of early pipeline issues.