### PR TITLE
Specify Bash Shell to Source Helper Script

### DIFF
--- a/.github/workflows/oracle-db-audit-replication-management.yml
+++ b/.github/workflows/oracle-db-audit-replication-management.yml
@@ -85,6 +85,7 @@ jobs:
       # For stopping it does not really matter, but for restarting we need to read the startup SCN from the database.
       - name: Prepare Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-build-ha.yml
+++ b/.github/workflows/oracle-db-build-ha.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Prepare Primary And All Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-delius-audit-replication-schema-setup.yml
+++ b/.github/workflows/oracle-db-delius-audit-replication-schema-setup.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Prepare Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-delius-configuration-artefacts.yml
+++ b/.github/workflows/oracle-db-delius-configuration-artefacts.yml
@@ -99,6 +99,7 @@ jobs:
 
       - name: Prepare Delius Primary And All Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-delius-operational-artefacts.yml
+++ b/.github/workflows/oracle-db-delius-operational-artefacts.yml
@@ -103,6 +103,7 @@ jobs:
 
       - name: Prepare Delius Primary And All Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-dg-switchover.yml
+++ b/.github/workflows/oracle-db-dg-switchover.yml
@@ -77,6 +77,7 @@ jobs:
 
       - name: Prepare Switchover Target Name
         id: preparetargetname
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-dms-setup.yml
+++ b/.github/workflows/oracle-db-dms-setup.yml
@@ -87,6 +87,7 @@ jobs:
 
       - name: Prepare Target Name
         id: preparetargetname
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-duplicate.yml
+++ b/.github/workflows/oracle-db-duplicate.yml
@@ -531,6 +531,7 @@ jobs:
 
       - name: Responding to Repository Dispatch event
         id: response
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-flashback-data-archive.yml
+++ b/.github/workflows/oracle-db-flashback-data-archive.yml
@@ -57,6 +57,7 @@ jobs:
 
       - name: Prepare Delius Primary And All Inventory Name
         id: prepareinventorynames
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-oem-blackout.yml
+++ b/.github/workflows/oracle-db-oem-blackout.yml
@@ -113,6 +113,7 @@ jobs:
 
       - name: Prepare Target Name
         id: preparetargetname
+        shell: bash
         run: |
           source "$PWD/operations/common/files/build_inventory_name.sh"
 

--- a/.github/workflows/oracle-db-schedule-validate-backups.yml
+++ b/.github/workflows/oracle-db-schedule-validate-backups.yml
@@ -30,6 +30,9 @@ jobs:
           ref: ${{ github.event_name == 'workflow_dispatch' && github.event.inputs.SourceCodeVersion || 'main' }}
           fetch-depth: 0
 
+      - name: Validate Backup Schedule JSON
+        run: jq empty operations/.github/workflows/oracle-db-validate-backups-schedule.json
+
       - name: Filter Validate Schedule
         id: filter-validate-schedule
         run: |
@@ -69,3 +72,32 @@ jobs:
     with:
       TargetEnvironment: ${{ matrix.TargetEnvironment }}
       TargetHost: ${{ matrix.TargetHost }}
+
+  # If the GHA fails during calculation of the scheduling matrix we will not have configured
+  # any specific environment to use yet, so we default to running the failure notification from
+  # the development OEM environment (this is arbitrary)
+  setup-notification-failure-slack:
+    if: failure()
+    runs-on: ubuntu-latest
+    container:
+      image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
+    needs: [prepare-run-matrix]
+    environment: "hmpps-oem-development-preapproved"
+    permissions:
+       id-token: write
+    steps:
+
+      - name: Checkout Local Repo to get Composite Action
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Send Slack Failure Notification
+        id: foreground_slack_notification
+        uses: ./.github/actions/send-slack-notification
+        env:
+            AWS_ACCOUNT_ID: "${{ vars.AWS_ACCOUNT_ID }}"
+        with:
+          Emoji: ":github-red:"
+          TextHeader: "Backup Validation Job Scheduling Failure"
+          TextBody: ":cross-red: Backup Validation job could not be scheduled"
+          TargetEnvironment: "GHA(Scheduling)"
+          JobName: "prepare-run-matrix"


### PR DESCRIPTION
This pull request updates several GitHub Actions workflow files to explicitly set the shell to `bash` for steps that source the `build_inventory_name.sh` script. This ensures consistent and reliable execution of the script across all workflows.

**Workflow consistency improvements:**

* Added `shell: bash` to all workflow steps that source the `build_inventory_name.sh` script in the following files:
  - `.github/workflows/oracle-db-audit-replication-management.yml`
  - `.github/workflows/oracle-db-build-ha.yml`
  - `.github/workflows/oracle-db-delius-audit-replication-schema-setup.yml`
  - `.github/workflows/oracle-db-delius-configuration-artefacts.yml`
  - `.github/workflows/oracle-db-delius-operational-artefacts.yml`
  - `.github/workflows/oracle-db-dg-switchover.yml`
  - `.github/workflows/oracle-db-dms-setup.yml`
  - `.github/workflows/oracle-db-duplicate.yml`
  - `.github/workflows/oracle-db-flashback-data-archive.yml`
  - `.github/workflows/oracle-db-oem-blackout.yml`

This change reduces the risk of shell compatibility issues and enforces best practices for script execution in CI workflows.