### PR TITLE
Treat unable to run a rotation because duplicate running as notifiable

### DIFF
--- a/.github/workflows/oracle-db-password-rotation.yml
+++ b/.github/workflows/oracle-db-password-rotation.yml
@@ -144,9 +144,11 @@ jobs:
 
           TargetEnvironment="environment_name_$(normalize_environment_name "${{ needs.oracle_password_preparation.outputs.TargetEnvironment }}")"
           DUPLICATE_JOBS_STATUS=$(aws ssm get-parameters --region eu-west-2 --names "/oracle-duplicate/${TargetEnvironment}_delius_primarydb" "/oracle-duplicate/${TargetEnvironment}_mis_primarydb" |  jq -r '.Parameters[].Value' | jq -r '.Phase' | uniq)
-          if [[ "${DUPLICATE_JOBS_STATUS}" == "Duplicate Started" ]]
+          if [[ "${DUPLICATE_JOBS_STATUS}" == *"Duplicate Started"* ]]
           then
             echo "SkipPasswordRotation=yes" >> $GITHUB_OUTPUT
+            echo "::error::Duplicate already in progress for ${TargetEnvironment}; treating this as a workflow failure and sending Slack notification."
+            exit 1
           fi
 
   oracle_password_rotation:
@@ -269,7 +271,7 @@ jobs:
           -e target_environment_name=${{ steps.definetargets.outputs.TargetEnvironment }} ${{ needs.oracle_password_preparation.outputs.VerboseOutput }} ${{ needs.oracle_password_preparation.outputs.AnsibleForks }}
 
   slack-notification:
-    if: ${{ failure() }}
+    if: ${{ always() && failure() }}
     runs-on: ubuntu-latest
     container:
       image: ghcr.io/ministryofjustice/hmpps-delius-operational-automation:0.80.0
@@ -302,12 +304,17 @@ jobs:
           if [[ "${{ needs.oracle_password_preparation.result }}" == "failure" ]]
           then
             echo "jobid=${{ needs.oracle_password_preparation.outputs.JobId }}" >> $GITHUB_OUTPUT
+            echo "reason=Preparation failed" >> $GITHUB_OUTPUT
           elif [[ "${{ needs.oracle_duplicate_in_progress.result }}" == "failure" ]]
           then
             echo "jobid=${{ needs.oracle_duplicate_in_progress.outputs.JobId }}" >> $GITHUB_OUTPUT
+            echo "reason=Duplicate already in progress, password rotation was skipped" >> $GITHUB_OUTPUT
           elif [[ "${{ needs.oracle_password_rotation.result }}" == "failure" ]]
           then
             echo "jobid=${{ needs.oracle_password_rotation.outputs.JobId }}" >> $GITHUB_OUTPUT
+            echo "reason=Password rotation execution failed" >> $GITHUB_OUTPUT
+          else
+            echo "reason=Workflow failed" >> $GITHUB_OUTPUT
           fi
 
       - name: Slack Failure Notification
@@ -345,6 +352,10 @@ jobs:
                           {
                             "type": "mrkdwn",
                             "text": "*Environment:*\n${{ needs.oracle_password_preparation.outputs.TargetEnvironment }}"
+                          },
+                          {
+                            "type": "mrkdwn",
+                            "text": "*Reason:*\n${{ steps.get-slack-token.outputs.reason }}"
                           }
                         ]
                     }  


### PR DESCRIPTION
This pull request improves the Oracle DB password rotation workflow by enhancing error handling and Slack notifications. The main changes ensure that duplicate job detection is more robust, failures are clearly reported with reasons, and Slack notifications always include the reason for failure.

**Error handling improvements:**
* The duplicate job check now matches any status containing "Duplicate Started" and immediately fails the workflow with an error message and Slack notification if a duplicate is detected.

**Slack notification enhancements:**
* The Slack notification job now always runs on workflow failure, ensuring notifications are sent in all failure scenarios.
* The failure reason is now captured and output for each failure scenario (preparation failure, duplicate in progress, rotation failure, or generic workflow failure).
* The Slack notification message now includes the explicit reason for failure, improving clarity for recipients.